### PR TITLE
QOL Improvements

### DIFF
--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -1,11 +1,7 @@
-Dark Mode:
-- List View
-- Tree View
-- Scroll Bars
-
-Mage 1.5:
-- Bulk theme export
+MAGE 1.5.0:
+- Theming support
 - Drag on Minimap Editor
 - Enable apply on "Auto connect" in Edit Door
 - Edit Sprites/Doors with double click
 - Input screens directly in Room Options
+- Screen number gets displayed as hex

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -7,3 +7,4 @@ MAGE 1.5.0:
 - Screen number gets displayed as hex
 - Added [MUSIC_STOP] Label for Fusion -> [\xBXXX]
 - Added Zoom to Text Editor
+- Input hex color in palette editor

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -10,3 +10,5 @@ MAGE 1.5.0:
 - Input hex color in palette editor
 - Door Exit Distance Presets
 - Added clipdata shortcuts button to main view
+- Zoom with Ctrl + Mouse Wheel in main view
+- Clear Sprites, Scrolls and Doors in Room Options

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -9,3 +9,4 @@ MAGE 1.5.0:
 - Added Zoom to Text Editor
 - Input hex color in palette editor
 - Door Exit Distance Presets
+- Added clipdata shortcuts button to main view

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -2,9 +2,10 @@ MAGE 1.5.0:
 - Theming support
 - Drag on Minimap Editor
 - Enable apply on "Auto connect" in Edit Door
-- Edit Sprites/Doors with double click
+- Edit Sprites/Scrolls/Doors with double click
 - Input screens directly in Room Options
 - Screen number gets displayed as hex
 - Added [MUSIC_STOP] Label for Fusion -> [\xBXXX]
 - Added Zoom to Text Editor
 - Input hex color in palette editor
+- Door Exit Distance Presets

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -5,3 +5,5 @@ MAGE 1.5.0:
 - Edit Sprites/Doors with double click
 - Input screens directly in Room Options
 - Screen number gets displayed as hex
+- Added [MUSIC_STOP] Label for Fusion -> [\xBXXX]
+- Added Zoom to Text Editor

--- a/ConnerTodo.txt
+++ b/ConnerTodo.txt
@@ -12,3 +12,4 @@ MAGE 1.5.0:
 - Added clipdata shortcuts button to main view
 - Zoom with Ctrl + Mouse Wheel in main view
 - Clear Sprites, Scrolls and Doors in Room Options
+- Drop Probability can be input as Percentage

--- a/mage/Editors/FormHeader.Designer.cs
+++ b/mage/Editors/FormHeader.Designer.cs
@@ -29,690 +29,903 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormHeader));
-            this.textBox_tileset = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_tileset = new System.Windows.Forms.Label();
-            this.textBox_BG0pointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG1pointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG2pointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG3pointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_CLPpointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG0prop = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG1prop = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG2prop = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_BG3prop = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_BG0 = new System.Windows.Forms.Label();
-            this.label_BG1 = new System.Windows.Forms.Label();
-            this.label_BG2 = new System.Windows.Forms.Label();
-            this.label_BG3 = new System.Windows.Forms.Label();
-            this.label_CLP = new System.Windows.Forms.Label();
-            this.label_BGpointer = new System.Windows.Forms.Label();
-            this.label_prop = new System.Windows.Forms.Label();
-            this.textBox_BG3scroll = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_transparency = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_BG3scroll = new System.Windows.Forms.Label();
-            this.label_transparency = new System.Windows.Forms.Label();
-            this.groupBox_BGdata = new System.Windows.Forms.GroupBox();
-            this.textBox_effectYpos = new mage.Theming.CustomControls.FlatTextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label_effect = new System.Windows.Forms.Label();
-            this.textBox_effect = new mage.Theming.CustomControls.FlatTextBox();
-            this.groupBox_spritesetData = new System.Windows.Forms.GroupBox();
-            this.label_second = new System.Windows.Forms.Label();
-            this.label_first = new System.Windows.Forms.Label();
-            this.label_default = new System.Windows.Forms.Label();
-            this.label_event = new System.Windows.Forms.Label();
-            this.label_spriteset = new System.Windows.Forms.Label();
-            this.label_spritesetPointer = new System.Windows.Forms.Label();
-            this.textBox_defaultPointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_defaultSpriteset = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_secondEvent = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_secondPointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_secondSpriteset = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_firstEvent = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_firstPointer = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_firstSpriteset = new mage.Theming.CustomControls.FlatTextBox();
-            this.groupBox_misc = new System.Windows.Forms.GroupBox();
-            this.label_music = new System.Windows.Forms.Label();
-            this.textBox_music = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_mapY = new System.Windows.Forms.Label();
-            this.label_mapX = new System.Windows.Forms.Label();
-            this.textBox_mapX = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_mapY = new mage.Theming.CustomControls.FlatTextBox();
-            this.button_apply = new System.Windows.Forms.Button();
-            this.button_close = new System.Windows.Forms.Button();
-            this.label_offset = new System.Windows.Forms.Label();
-            this.textBox_offsetVal = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_room = new System.Windows.Forms.Label();
-            this.label_area = new System.Windows.Forms.Label();
-            this.comboBox_room = new mage.Theming.CustomControls.FlatComboBox();
-            this.comboBox_area = new mage.Theming.CustomControls.FlatComboBox();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
-            this.groupBox_BGdata.SuspendLayout();
-            this.groupBox_spritesetData.SuspendLayout();
-            this.groupBox_misc.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            this.SuspendLayout();
+            textBox_tileset = new Theming.CustomControls.FlatTextBox();
+            label_tileset = new System.Windows.Forms.Label();
+            textBox_BG0pointer = new Theming.CustomControls.FlatTextBox();
+            textBox_BG1pointer = new Theming.CustomControls.FlatTextBox();
+            textBox_BG2pointer = new Theming.CustomControls.FlatTextBox();
+            textBox_BG3pointer = new Theming.CustomControls.FlatTextBox();
+            textBox_CLPpointer = new Theming.CustomControls.FlatTextBox();
+            textBox_BG0prop = new Theming.CustomControls.FlatTextBox();
+            textBox_BG1prop = new Theming.CustomControls.FlatTextBox();
+            textBox_BG2prop = new Theming.CustomControls.FlatTextBox();
+            textBox_BG3prop = new Theming.CustomControls.FlatTextBox();
+            label_BG0 = new System.Windows.Forms.Label();
+            label_BG1 = new System.Windows.Forms.Label();
+            label_BG2 = new System.Windows.Forms.Label();
+            label_BG3 = new System.Windows.Forms.Label();
+            label_CLP = new System.Windows.Forms.Label();
+            label_BGpointer = new System.Windows.Forms.Label();
+            label_prop = new System.Windows.Forms.Label();
+            textBox_BG3scroll = new Theming.CustomControls.FlatTextBox();
+            textBox_transparency = new Theming.CustomControls.FlatTextBox();
+            label_BG3scroll = new System.Windows.Forms.Label();
+            label_transparency = new System.Windows.Forms.Label();
+            groupBox_BGdata = new System.Windows.Forms.GroupBox();
+            textBox_effectYpos = new Theming.CustomControls.FlatTextBox();
+            label1 = new System.Windows.Forms.Label();
+            label_effect = new System.Windows.Forms.Label();
+            textBox_effect = new Theming.CustomControls.FlatTextBox();
+            groupBox_spritesetData = new System.Windows.Forms.GroupBox();
+            label_second = new System.Windows.Forms.Label();
+            label_first = new System.Windows.Forms.Label();
+            label_default = new System.Windows.Forms.Label();
+            label_event = new System.Windows.Forms.Label();
+            label_spriteset = new System.Windows.Forms.Label();
+            label_spritesetPointer = new System.Windows.Forms.Label();
+            textBox_defaultPointer = new Theming.CustomControls.FlatTextBox();
+            textBox_defaultSpriteset = new Theming.CustomControls.FlatTextBox();
+            textBox_secondEvent = new Theming.CustomControls.FlatTextBox();
+            textBox_secondPointer = new Theming.CustomControls.FlatTextBox();
+            textBox_secondSpriteset = new Theming.CustomControls.FlatTextBox();
+            textBox_firstEvent = new Theming.CustomControls.FlatTextBox();
+            textBox_firstPointer = new Theming.CustomControls.FlatTextBox();
+            textBox_firstSpriteset = new Theming.CustomControls.FlatTextBox();
+            groupBox_misc = new System.Windows.Forms.GroupBox();
+            label_music = new System.Windows.Forms.Label();
+            textBox_music = new Theming.CustomControls.FlatTextBox();
+            label_mapY = new System.Windows.Forms.Label();
+            label_mapX = new System.Windows.Forms.Label();
+            textBox_mapX = new Theming.CustomControls.FlatTextBox();
+            textBox_mapY = new Theming.CustomControls.FlatTextBox();
+            button_apply = new System.Windows.Forms.Button();
+            button_close = new System.Windows.Forms.Button();
+            label_offset = new System.Windows.Forms.Label();
+            textBox_offsetVal = new Theming.CustomControls.FlatTextBox();
+            label_room = new System.Windows.Forms.Label();
+            label_area = new System.Windows.Forms.Label();
+            comboBox_room = new Theming.CustomControls.FlatComboBox();
+            comboBox_area = new Theming.CustomControls.FlatComboBox();
+            statusStrip = new System.Windows.Forms.StatusStrip();
+            statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
+            groupBox_BGdata.SuspendLayout();
+            groupBox_spritesetData.SuspendLayout();
+            groupBox_misc.SuspendLayout();
+            statusStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // textBox_tileset
             // 
-            this.textBox_tileset.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_tileset.Location = new System.Drawing.Point(87, 35);
-            this.textBox_tileset.Name = "textBox_tileset";
-            this.textBox_tileset.Size = new System.Drawing.Size(30, 20);
-            this.textBox_tileset.TabIndex = 0;
-            this.textBox_tileset.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_tileset.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_tileset.Location = new System.Drawing.Point(102, 40);
+            textBox_tileset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_tileset.Multiline = false;
+            textBox_tileset.Name = "textBox_tileset";
+            textBox_tileset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_tileset.ReadOnly = false;
+            textBox_tileset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_tileset.SelectionStart = 0;
+            textBox_tileset.Size = new System.Drawing.Size(35, 23);
+            textBox_tileset.TabIndex = 0;
+            textBox_tileset.WordWrap = true;
+            textBox_tileset.TextChanged += textBox_TextChanged;
             // 
             // label_tileset
             // 
-            this.label_tileset.AutoSize = true;
-            this.label_tileset.Location = new System.Drawing.Point(6, 38);
-            this.label_tileset.Name = "label_tileset";
-            this.label_tileset.Size = new System.Drawing.Size(41, 13);
-            this.label_tileset.TabIndex = 0;
-            this.label_tileset.Text = "Tileset:";
+            label_tileset.AutoSize = true;
+            label_tileset.Location = new System.Drawing.Point(7, 44);
+            label_tileset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_tileset.Name = "label_tileset";
+            label_tileset.Size = new System.Drawing.Size(43, 15);
+            label_tileset.TabIndex = 0;
+            label_tileset.Text = "Tileset:";
             // 
             // textBox_BG0pointer
             // 
-            this.textBox_BG0pointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG0pointer.Location = new System.Drawing.Point(193, 35);
-            this.textBox_BG0pointer.Name = "textBox_BG0pointer";
-            this.textBox_BG0pointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_BG0pointer.TabIndex = 5;
-            this.textBox_BG0pointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG0pointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG0pointer.Location = new System.Drawing.Point(225, 40);
+            textBox_BG0pointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG0pointer.Multiline = false;
+            textBox_BG0pointer.Name = "textBox_BG0pointer";
+            textBox_BG0pointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG0pointer.ReadOnly = false;
+            textBox_BG0pointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG0pointer.SelectionStart = 0;
+            textBox_BG0pointer.Size = new System.Drawing.Size(76, 23);
+            textBox_BG0pointer.TabIndex = 5;
+            textBox_BG0pointer.WordWrap = true;
+            textBox_BG0pointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG1pointer
             // 
-            this.textBox_BG1pointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG1pointer.Location = new System.Drawing.Point(193, 61);
-            this.textBox_BG1pointer.Name = "textBox_BG1pointer";
-            this.textBox_BG1pointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_BG1pointer.TabIndex = 7;
-            this.textBox_BG1pointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG1pointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG1pointer.Location = new System.Drawing.Point(225, 70);
+            textBox_BG1pointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG1pointer.Multiline = false;
+            textBox_BG1pointer.Name = "textBox_BG1pointer";
+            textBox_BG1pointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG1pointer.ReadOnly = false;
+            textBox_BG1pointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG1pointer.SelectionStart = 0;
+            textBox_BG1pointer.Size = new System.Drawing.Size(76, 23);
+            textBox_BG1pointer.TabIndex = 7;
+            textBox_BG1pointer.WordWrap = true;
+            textBox_BG1pointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG2pointer
             // 
-            this.textBox_BG2pointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG2pointer.Location = new System.Drawing.Point(193, 87);
-            this.textBox_BG2pointer.Name = "textBox_BG2pointer";
-            this.textBox_BG2pointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_BG2pointer.TabIndex = 9;
-            this.textBox_BG2pointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG2pointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG2pointer.Location = new System.Drawing.Point(225, 100);
+            textBox_BG2pointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG2pointer.Multiline = false;
+            textBox_BG2pointer.Name = "textBox_BG2pointer";
+            textBox_BG2pointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG2pointer.ReadOnly = false;
+            textBox_BG2pointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG2pointer.SelectionStart = 0;
+            textBox_BG2pointer.Size = new System.Drawing.Size(76, 23);
+            textBox_BG2pointer.TabIndex = 9;
+            textBox_BG2pointer.WordWrap = true;
+            textBox_BG2pointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG3pointer
             // 
-            this.textBox_BG3pointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG3pointer.Location = new System.Drawing.Point(193, 113);
-            this.textBox_BG3pointer.Name = "textBox_BG3pointer";
-            this.textBox_BG3pointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_BG3pointer.TabIndex = 11;
-            this.textBox_BG3pointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG3pointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG3pointer.Location = new System.Drawing.Point(225, 130);
+            textBox_BG3pointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG3pointer.Multiline = false;
+            textBox_BG3pointer.Name = "textBox_BG3pointer";
+            textBox_BG3pointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG3pointer.ReadOnly = false;
+            textBox_BG3pointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG3pointer.SelectionStart = 0;
+            textBox_BG3pointer.Size = new System.Drawing.Size(76, 23);
+            textBox_BG3pointer.TabIndex = 11;
+            textBox_BG3pointer.WordWrap = true;
+            textBox_BG3pointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_CLPpointer
             // 
-            this.textBox_CLPpointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_CLPpointer.Location = new System.Drawing.Point(193, 139);
-            this.textBox_CLPpointer.Name = "textBox_CLPpointer";
-            this.textBox_CLPpointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_CLPpointer.TabIndex = 13;
-            this.textBox_CLPpointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_CLPpointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_CLPpointer.Location = new System.Drawing.Point(225, 160);
+            textBox_CLPpointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_CLPpointer.Multiline = false;
+            textBox_CLPpointer.Name = "textBox_CLPpointer";
+            textBox_CLPpointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_CLPpointer.ReadOnly = false;
+            textBox_CLPpointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_CLPpointer.SelectionStart = 0;
+            textBox_CLPpointer.Size = new System.Drawing.Size(76, 23);
+            textBox_CLPpointer.TabIndex = 13;
+            textBox_CLPpointer.WordWrap = true;
+            textBox_CLPpointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG0prop
             // 
-            this.textBox_BG0prop.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG0prop.Location = new System.Drawing.Point(264, 35);
-            this.textBox_BG0prop.Name = "textBox_BG0prop";
-            this.textBox_BG0prop.Size = new System.Drawing.Size(30, 20);
-            this.textBox_BG0prop.TabIndex = 6;
-            this.textBox_BG0prop.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG0prop.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG0prop.Location = new System.Drawing.Point(308, 40);
+            textBox_BG0prop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG0prop.Multiline = false;
+            textBox_BG0prop.Name = "textBox_BG0prop";
+            textBox_BG0prop.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG0prop.ReadOnly = false;
+            textBox_BG0prop.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG0prop.SelectionStart = 0;
+            textBox_BG0prop.Size = new System.Drawing.Size(35, 23);
+            textBox_BG0prop.TabIndex = 6;
+            textBox_BG0prop.WordWrap = true;
+            textBox_BG0prop.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG1prop
             // 
-            this.textBox_BG1prop.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG1prop.Location = new System.Drawing.Point(264, 61);
-            this.textBox_BG1prop.Name = "textBox_BG1prop";
-            this.textBox_BG1prop.Size = new System.Drawing.Size(30, 20);
-            this.textBox_BG1prop.TabIndex = 8;
-            this.textBox_BG1prop.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG1prop.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG1prop.Location = new System.Drawing.Point(308, 70);
+            textBox_BG1prop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG1prop.Multiline = false;
+            textBox_BG1prop.Name = "textBox_BG1prop";
+            textBox_BG1prop.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG1prop.ReadOnly = false;
+            textBox_BG1prop.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG1prop.SelectionStart = 0;
+            textBox_BG1prop.Size = new System.Drawing.Size(35, 23);
+            textBox_BG1prop.TabIndex = 8;
+            textBox_BG1prop.WordWrap = true;
+            textBox_BG1prop.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG2prop
             // 
-            this.textBox_BG2prop.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG2prop.Location = new System.Drawing.Point(264, 87);
-            this.textBox_BG2prop.Name = "textBox_BG2prop";
-            this.textBox_BG2prop.Size = new System.Drawing.Size(30, 20);
-            this.textBox_BG2prop.TabIndex = 10;
-            this.textBox_BG2prop.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG2prop.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG2prop.Location = new System.Drawing.Point(308, 100);
+            textBox_BG2prop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG2prop.Multiline = false;
+            textBox_BG2prop.Name = "textBox_BG2prop";
+            textBox_BG2prop.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG2prop.ReadOnly = false;
+            textBox_BG2prop.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG2prop.SelectionStart = 0;
+            textBox_BG2prop.Size = new System.Drawing.Size(35, 23);
+            textBox_BG2prop.TabIndex = 10;
+            textBox_BG2prop.WordWrap = true;
+            textBox_BG2prop.TextChanged += textBox_TextChanged;
             // 
             // textBox_BG3prop
             // 
-            this.textBox_BG3prop.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG3prop.Location = new System.Drawing.Point(264, 113);
-            this.textBox_BG3prop.Name = "textBox_BG3prop";
-            this.textBox_BG3prop.Size = new System.Drawing.Size(30, 20);
-            this.textBox_BG3prop.TabIndex = 12;
-            this.textBox_BG3prop.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG3prop.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG3prop.Location = new System.Drawing.Point(308, 130);
+            textBox_BG3prop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG3prop.Multiline = false;
+            textBox_BG3prop.Name = "textBox_BG3prop";
+            textBox_BG3prop.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG3prop.ReadOnly = false;
+            textBox_BG3prop.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG3prop.SelectionStart = 0;
+            textBox_BG3prop.Size = new System.Drawing.Size(35, 23);
+            textBox_BG3prop.TabIndex = 12;
+            textBox_BG3prop.WordWrap = true;
+            textBox_BG3prop.TextChanged += textBox_TextChanged;
             // 
             // label_BG0
             // 
-            this.label_BG0.AutoSize = true;
-            this.label_BG0.Location = new System.Drawing.Point(153, 38);
-            this.label_BG0.Name = "label_BG0";
-            this.label_BG0.Size = new System.Drawing.Size(34, 13);
-            this.label_BG0.TabIndex = 0;
-            this.label_BG0.Text = "BG 0:";
+            label_BG0.AutoSize = true;
+            label_BG0.Location = new System.Drawing.Point(178, 44);
+            label_BG0.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BG0.Name = "label_BG0";
+            label_BG0.Size = new System.Drawing.Size(34, 15);
+            label_BG0.TabIndex = 0;
+            label_BG0.Text = "BG 0:";
             // 
             // label_BG1
             // 
-            this.label_BG1.AutoSize = true;
-            this.label_BG1.Location = new System.Drawing.Point(153, 64);
-            this.label_BG1.Name = "label_BG1";
-            this.label_BG1.Size = new System.Drawing.Size(34, 13);
-            this.label_BG1.TabIndex = 0;
-            this.label_BG1.Text = "BG 1:";
+            label_BG1.AutoSize = true;
+            label_BG1.Location = new System.Drawing.Point(178, 74);
+            label_BG1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BG1.Name = "label_BG1";
+            label_BG1.Size = new System.Drawing.Size(34, 15);
+            label_BG1.TabIndex = 0;
+            label_BG1.Text = "BG 1:";
             // 
             // label_BG2
             // 
-            this.label_BG2.AutoSize = true;
-            this.label_BG2.Location = new System.Drawing.Point(153, 90);
-            this.label_BG2.Name = "label_BG2";
-            this.label_BG2.Size = new System.Drawing.Size(34, 13);
-            this.label_BG2.TabIndex = 0;
-            this.label_BG2.Text = "BG 2:";
+            label_BG2.AutoSize = true;
+            label_BG2.Location = new System.Drawing.Point(178, 104);
+            label_BG2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BG2.Name = "label_BG2";
+            label_BG2.Size = new System.Drawing.Size(34, 15);
+            label_BG2.TabIndex = 0;
+            label_BG2.Text = "BG 2:";
             // 
             // label_BG3
             // 
-            this.label_BG3.AutoSize = true;
-            this.label_BG3.Location = new System.Drawing.Point(153, 116);
-            this.label_BG3.Name = "label_BG3";
-            this.label_BG3.Size = new System.Drawing.Size(34, 13);
-            this.label_BG3.TabIndex = 0;
-            this.label_BG3.Text = "BG 3:";
+            label_BG3.AutoSize = true;
+            label_BG3.Location = new System.Drawing.Point(178, 134);
+            label_BG3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BG3.Name = "label_BG3";
+            label_BG3.Size = new System.Drawing.Size(34, 15);
+            label_BG3.TabIndex = 0;
+            label_BG3.Text = "BG 3:";
             // 
             // label_CLP
             // 
-            this.label_CLP.AutoSize = true;
-            this.label_CLP.Location = new System.Drawing.Point(153, 142);
-            this.label_CLP.Name = "label_CLP";
-            this.label_CLP.Size = new System.Drawing.Size(27, 13);
-            this.label_CLP.TabIndex = 0;
-            this.label_CLP.Text = "Clip:";
+            label_CLP.AutoSize = true;
+            label_CLP.Location = new System.Drawing.Point(178, 164);
+            label_CLP.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_CLP.Name = "label_CLP";
+            label_CLP.Size = new System.Drawing.Size(31, 15);
+            label_CLP.TabIndex = 0;
+            label_CLP.Text = "Clip:";
             // 
             // label_BGpointer
             // 
-            this.label_BGpointer.AutoSize = true;
-            this.label_BGpointer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_BGpointer.Location = new System.Drawing.Point(193, 16);
-            this.label_BGpointer.Name = "label_BGpointer";
-            this.label_BGpointer.Size = new System.Drawing.Size(40, 13);
-            this.label_BGpointer.TabIndex = 0;
-            this.label_BGpointer.Text = "Pointer";
+            label_BGpointer.AutoSize = true;
+            label_BGpointer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_BGpointer.Location = new System.Drawing.Point(225, 18);
+            label_BGpointer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BGpointer.Name = "label_BGpointer";
+            label_BGpointer.Size = new System.Drawing.Size(40, 13);
+            label_BGpointer.TabIndex = 0;
+            label_BGpointer.Text = "Pointer";
             // 
             // label_prop
             // 
-            this.label_prop.AutoSize = true;
-            this.label_prop.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_prop.Location = new System.Drawing.Point(263, 16);
-            this.label_prop.Name = "label_prop";
-            this.label_prop.Size = new System.Drawing.Size(29, 13);
-            this.label_prop.TabIndex = 0;
-            this.label_prop.Text = "Prop";
+            label_prop.AutoSize = true;
+            label_prop.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_prop.Location = new System.Drawing.Point(307, 18);
+            label_prop.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_prop.Name = "label_prop";
+            label_prop.Size = new System.Drawing.Size(29, 13);
+            label_prop.TabIndex = 0;
+            label_prop.Text = "Prop";
             // 
             // textBox_BG3scroll
             // 
-            this.textBox_BG3scroll.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_BG3scroll.Location = new System.Drawing.Point(87, 87);
-            this.textBox_BG3scroll.Name = "textBox_BG3scroll";
-            this.textBox_BG3scroll.Size = new System.Drawing.Size(30, 20);
-            this.textBox_BG3scroll.TabIndex = 2;
-            this.textBox_BG3scroll.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_BG3scroll.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_BG3scroll.Location = new System.Drawing.Point(102, 100);
+            textBox_BG3scroll.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_BG3scroll.Multiline = false;
+            textBox_BG3scroll.Name = "textBox_BG3scroll";
+            textBox_BG3scroll.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_BG3scroll.ReadOnly = false;
+            textBox_BG3scroll.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_BG3scroll.SelectionStart = 0;
+            textBox_BG3scroll.Size = new System.Drawing.Size(35, 23);
+            textBox_BG3scroll.TabIndex = 2;
+            textBox_BG3scroll.WordWrap = true;
+            textBox_BG3scroll.TextChanged += textBox_TextChanged;
             // 
             // textBox_transparency
             // 
-            this.textBox_transparency.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_transparency.Location = new System.Drawing.Point(87, 61);
-            this.textBox_transparency.Name = "textBox_transparency";
-            this.textBox_transparency.Size = new System.Drawing.Size(30, 20);
-            this.textBox_transparency.TabIndex = 1;
-            this.textBox_transparency.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_transparency.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_transparency.Location = new System.Drawing.Point(102, 70);
+            textBox_transparency.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_transparency.Multiline = false;
+            textBox_transparency.Name = "textBox_transparency";
+            textBox_transparency.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_transparency.ReadOnly = false;
+            textBox_transparency.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_transparency.SelectionStart = 0;
+            textBox_transparency.Size = new System.Drawing.Size(35, 23);
+            textBox_transparency.TabIndex = 1;
+            textBox_transparency.WordWrap = true;
+            textBox_transparency.TextChanged += textBox_TextChanged;
             // 
             // label_BG3scroll
             // 
-            this.label_BG3scroll.AutoSize = true;
-            this.label_BG3scroll.Location = new System.Drawing.Point(6, 90);
-            this.label_BG3scroll.Name = "label_BG3scroll";
-            this.label_BG3scroll.Size = new System.Drawing.Size(58, 13);
-            this.label_BG3scroll.TabIndex = 0;
-            this.label_BG3scroll.Text = "BG3 scroll:";
+            label_BG3scroll.AutoSize = true;
+            label_BG3scroll.Location = new System.Drawing.Point(7, 104);
+            label_BG3scroll.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_BG3scroll.Name = "label_BG3scroll";
+            label_BG3scroll.Size = new System.Drawing.Size(62, 15);
+            label_BG3scroll.TabIndex = 0;
+            label_BG3scroll.Text = "BG3 scroll:";
             // 
             // label_transparency
             // 
-            this.label_transparency.AutoSize = true;
-            this.label_transparency.Location = new System.Drawing.Point(6, 64);
-            this.label_transparency.Name = "label_transparency";
-            this.label_transparency.Size = new System.Drawing.Size(75, 13);
-            this.label_transparency.TabIndex = 0;
-            this.label_transparency.Text = "Transparency:";
+            label_transparency.AutoSize = true;
+            label_transparency.Location = new System.Drawing.Point(7, 74);
+            label_transparency.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_transparency.Name = "label_transparency";
+            label_transparency.Size = new System.Drawing.Size(79, 15);
+            label_transparency.TabIndex = 0;
+            label_transparency.Text = "Transparency:";
             // 
             // groupBox_BGdata
             // 
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG0pointer);
-            this.groupBox_BGdata.Controls.Add(this.label_transparency);
-            this.groupBox_BGdata.Controls.Add(this.textBox_effectYpos);
-            this.groupBox_BGdata.Controls.Add(this.label1);
-            this.groupBox_BGdata.Controls.Add(this.label_BG3scroll);
-            this.groupBox_BGdata.Controls.Add(this.label_effect);
-            this.groupBox_BGdata.Controls.Add(this.textBox_effect);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG1pointer);
-            this.groupBox_BGdata.Controls.Add(this.textBox_transparency);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG3prop);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG3scroll);
-            this.groupBox_BGdata.Controls.Add(this.label_BG3);
-            this.groupBox_BGdata.Controls.Add(this.label_tileset);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG2pointer);
-            this.groupBox_BGdata.Controls.Add(this.textBox_tileset);
-            this.groupBox_BGdata.Controls.Add(this.label_BG2);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG2prop);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG3pointer);
-            this.groupBox_BGdata.Controls.Add(this.label_BG0);
-            this.groupBox_BGdata.Controls.Add(this.label_CLP);
-            this.groupBox_BGdata.Controls.Add(this.textBox_CLPpointer);
-            this.groupBox_BGdata.Controls.Add(this.label_BG1);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG1prop);
-            this.groupBox_BGdata.Controls.Add(this.label_prop);
-            this.groupBox_BGdata.Controls.Add(this.label_BGpointer);
-            this.groupBox_BGdata.Controls.Add(this.textBox_BG0prop);
-            this.groupBox_BGdata.Location = new System.Drawing.Point(12, 12);
-            this.groupBox_BGdata.Name = "groupBox_BGdata";
-            this.groupBox_BGdata.Size = new System.Drawing.Size(303, 168);
-            this.groupBox_BGdata.TabIndex = 0;
-            this.groupBox_BGdata.TabStop = false;
-            this.groupBox_BGdata.Text = "Background Data";
+            groupBox_BGdata.Controls.Add(textBox_BG0pointer);
+            groupBox_BGdata.Controls.Add(label_transparency);
+            groupBox_BGdata.Controls.Add(textBox_effectYpos);
+            groupBox_BGdata.Controls.Add(label1);
+            groupBox_BGdata.Controls.Add(label_BG3scroll);
+            groupBox_BGdata.Controls.Add(label_effect);
+            groupBox_BGdata.Controls.Add(textBox_effect);
+            groupBox_BGdata.Controls.Add(textBox_BG1pointer);
+            groupBox_BGdata.Controls.Add(textBox_transparency);
+            groupBox_BGdata.Controls.Add(textBox_BG3prop);
+            groupBox_BGdata.Controls.Add(textBox_BG3scroll);
+            groupBox_BGdata.Controls.Add(label_BG3);
+            groupBox_BGdata.Controls.Add(label_tileset);
+            groupBox_BGdata.Controls.Add(textBox_BG2pointer);
+            groupBox_BGdata.Controls.Add(textBox_tileset);
+            groupBox_BGdata.Controls.Add(label_BG2);
+            groupBox_BGdata.Controls.Add(textBox_BG2prop);
+            groupBox_BGdata.Controls.Add(textBox_BG3pointer);
+            groupBox_BGdata.Controls.Add(label_BG0);
+            groupBox_BGdata.Controls.Add(label_CLP);
+            groupBox_BGdata.Controls.Add(textBox_CLPpointer);
+            groupBox_BGdata.Controls.Add(label_BG1);
+            groupBox_BGdata.Controls.Add(textBox_BG1prop);
+            groupBox_BGdata.Controls.Add(label_prop);
+            groupBox_BGdata.Controls.Add(label_BGpointer);
+            groupBox_BGdata.Controls.Add(textBox_BG0prop);
+            groupBox_BGdata.Location = new System.Drawing.Point(14, 14);
+            groupBox_BGdata.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_BGdata.Name = "groupBox_BGdata";
+            groupBox_BGdata.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_BGdata.Size = new System.Drawing.Size(354, 194);
+            groupBox_BGdata.TabIndex = 0;
+            groupBox_BGdata.TabStop = false;
+            groupBox_BGdata.Text = "Background Data";
             // 
             // textBox_effectYpos
             // 
-            this.textBox_effectYpos.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_effectYpos.Location = new System.Drawing.Point(87, 139);
-            this.textBox_effectYpos.Name = "textBox_effectYpos";
-            this.textBox_effectYpos.Size = new System.Drawing.Size(30, 20);
-            this.textBox_effectYpos.TabIndex = 4;
-            this.textBox_effectYpos.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_effectYpos.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_effectYpos.Location = new System.Drawing.Point(102, 160);
+            textBox_effectYpos.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_effectYpos.Multiline = false;
+            textBox_effectYpos.Name = "textBox_effectYpos";
+            textBox_effectYpos.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_effectYpos.ReadOnly = false;
+            textBox_effectYpos.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_effectYpos.SelectionStart = 0;
+            textBox_effectYpos.Size = new System.Drawing.Size(35, 23);
+            textBox_effectYpos.TabIndex = 4;
+            textBox_effectYpos.WordWrap = true;
+            textBox_effectYpos.TextChanged += textBox_TextChanged;
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 142);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(68, 13);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Effect Y pos:";
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(7, 164);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(72, 15);
+            label1.TabIndex = 0;
+            label1.Text = "Effect Y pos:";
             // 
             // label_effect
             // 
-            this.label_effect.AutoSize = true;
-            this.label_effect.Location = new System.Drawing.Point(6, 116);
-            this.label_effect.Name = "label_effect";
-            this.label_effect.Size = new System.Drawing.Size(38, 13);
-            this.label_effect.TabIndex = 0;
-            this.label_effect.Text = "Effect:";
+            label_effect.AutoSize = true;
+            label_effect.Location = new System.Drawing.Point(7, 134);
+            label_effect.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_effect.Name = "label_effect";
+            label_effect.Size = new System.Drawing.Size(40, 15);
+            label_effect.TabIndex = 0;
+            label_effect.Text = "Effect:";
             // 
             // textBox_effect
             // 
-            this.textBox_effect.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_effect.Location = new System.Drawing.Point(87, 113);
-            this.textBox_effect.Name = "textBox_effect";
-            this.textBox_effect.Size = new System.Drawing.Size(30, 20);
-            this.textBox_effect.TabIndex = 3;
-            this.textBox_effect.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_effect.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_effect.Location = new System.Drawing.Point(102, 130);
+            textBox_effect.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_effect.Multiline = false;
+            textBox_effect.Name = "textBox_effect";
+            textBox_effect.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_effect.ReadOnly = false;
+            textBox_effect.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_effect.SelectionStart = 0;
+            textBox_effect.Size = new System.Drawing.Size(35, 23);
+            textBox_effect.TabIndex = 3;
+            textBox_effect.WordWrap = true;
+            textBox_effect.TextChanged += textBox_TextChanged;
             // 
             // groupBox_spritesetData
             // 
-            this.groupBox_spritesetData.Controls.Add(this.label_second);
-            this.groupBox_spritesetData.Controls.Add(this.label_first);
-            this.groupBox_spritesetData.Controls.Add(this.label_default);
-            this.groupBox_spritesetData.Controls.Add(this.label_event);
-            this.groupBox_spritesetData.Controls.Add(this.label_spriteset);
-            this.groupBox_spritesetData.Controls.Add(this.label_spritesetPointer);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_defaultPointer);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_defaultSpriteset);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_secondEvent);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_secondPointer);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_secondSpriteset);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_firstEvent);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_firstPointer);
-            this.groupBox_spritesetData.Controls.Add(this.textBox_firstSpriteset);
-            this.groupBox_spritesetData.Location = new System.Drawing.Point(12, 186);
-            this.groupBox_spritesetData.Name = "groupBox_spritesetData";
-            this.groupBox_spritesetData.Size = new System.Drawing.Size(205, 118);
-            this.groupBox_spritesetData.TabIndex = 1;
-            this.groupBox_spritesetData.TabStop = false;
-            this.groupBox_spritesetData.Text = "Spriteset Data";
+            groupBox_spritesetData.Controls.Add(label_second);
+            groupBox_spritesetData.Controls.Add(label_first);
+            groupBox_spritesetData.Controls.Add(label_default);
+            groupBox_spritesetData.Controls.Add(label_event);
+            groupBox_spritesetData.Controls.Add(label_spriteset);
+            groupBox_spritesetData.Controls.Add(label_spritesetPointer);
+            groupBox_spritesetData.Controls.Add(textBox_defaultPointer);
+            groupBox_spritesetData.Controls.Add(textBox_defaultSpriteset);
+            groupBox_spritesetData.Controls.Add(textBox_secondEvent);
+            groupBox_spritesetData.Controls.Add(textBox_secondPointer);
+            groupBox_spritesetData.Controls.Add(textBox_secondSpriteset);
+            groupBox_spritesetData.Controls.Add(textBox_firstEvent);
+            groupBox_spritesetData.Controls.Add(textBox_firstPointer);
+            groupBox_spritesetData.Controls.Add(textBox_firstSpriteset);
+            groupBox_spritesetData.Location = new System.Drawing.Point(14, 215);
+            groupBox_spritesetData.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_spritesetData.Name = "groupBox_spritesetData";
+            groupBox_spritesetData.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_spritesetData.Size = new System.Drawing.Size(239, 136);
+            groupBox_spritesetData.TabIndex = 1;
+            groupBox_spritesetData.TabStop = false;
+            groupBox_spritesetData.Text = "Spriteset Data";
             // 
             // label_second
             // 
-            this.label_second.AutoSize = true;
-            this.label_second.Location = new System.Drawing.Point(6, 90);
-            this.label_second.Name = "label_second";
-            this.label_second.Size = new System.Drawing.Size(47, 13);
-            this.label_second.TabIndex = 0;
-            this.label_second.Text = "Second:";
+            label_second.AutoSize = true;
+            label_second.Location = new System.Drawing.Point(7, 104);
+            label_second.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_second.Name = "label_second";
+            label_second.Size = new System.Drawing.Size(49, 15);
+            label_second.TabIndex = 0;
+            label_second.Text = "Second:";
             // 
             // label_first
             // 
-            this.label_first.AutoSize = true;
-            this.label_first.Location = new System.Drawing.Point(6, 64);
-            this.label_first.Name = "label_first";
-            this.label_first.Size = new System.Drawing.Size(29, 13);
-            this.label_first.TabIndex = 0;
-            this.label_first.Text = "First:";
+            label_first.AutoSize = true;
+            label_first.Location = new System.Drawing.Point(7, 74);
+            label_first.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_first.Name = "label_first";
+            label_first.Size = new System.Drawing.Size(32, 15);
+            label_first.TabIndex = 0;
+            label_first.Text = "First:";
             // 
             // label_default
             // 
-            this.label_default.AutoSize = true;
-            this.label_default.Location = new System.Drawing.Point(6, 38);
-            this.label_default.Name = "label_default";
-            this.label_default.Size = new System.Drawing.Size(44, 13);
-            this.label_default.TabIndex = 0;
-            this.label_default.Text = "Default:";
+            label_default.AutoSize = true;
+            label_default.Location = new System.Drawing.Point(7, 44);
+            label_default.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_default.Name = "label_default";
+            label_default.Size = new System.Drawing.Size(48, 15);
+            label_default.TabIndex = 0;
+            label_default.Text = "Default:";
             // 
             // label_event
             // 
-            this.label_event.AutoSize = true;
-            this.label_event.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_event.Location = new System.Drawing.Point(165, 16);
-            this.label_event.Name = "label_event";
-            this.label_event.Size = new System.Drawing.Size(35, 13);
-            this.label_event.TabIndex = 0;
-            this.label_event.Text = "Event";
+            label_event.AutoSize = true;
+            label_event.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_event.Location = new System.Drawing.Point(192, 18);
+            label_event.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_event.Name = "label_event";
+            label_event.Size = new System.Drawing.Size(35, 13);
+            label_event.TabIndex = 0;
+            label_event.Text = "Event";
             // 
             // label_spriteset
             // 
-            this.label_spriteset.AutoSize = true;
-            this.label_spriteset.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_spriteset.Location = new System.Drawing.Point(130, 16);
-            this.label_spriteset.Name = "label_spriteset";
-            this.label_spriteset.Size = new System.Drawing.Size(23, 13);
-            this.label_spriteset.TabIndex = 0;
-            this.label_spriteset.Text = "Set";
+            label_spriteset.AutoSize = true;
+            label_spriteset.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_spriteset.Location = new System.Drawing.Point(152, 18);
+            label_spriteset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_spriteset.Name = "label_spriteset";
+            label_spriteset.Size = new System.Drawing.Size(23, 13);
+            label_spriteset.TabIndex = 0;
+            label_spriteset.Text = "Set";
             // 
             // label_spritesetPointer
             // 
-            this.label_spritesetPointer.AutoSize = true;
-            this.label_spritesetPointer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_spritesetPointer.Location = new System.Drawing.Point(59, 16);
-            this.label_spritesetPointer.Name = "label_spritesetPointer";
-            this.label_spritesetPointer.Size = new System.Drawing.Size(40, 13);
-            this.label_spritesetPointer.TabIndex = 0;
-            this.label_spritesetPointer.Text = "Pointer";
+            label_spritesetPointer.AutoSize = true;
+            label_spritesetPointer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_spritesetPointer.Location = new System.Drawing.Point(69, 18);
+            label_spritesetPointer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_spritesetPointer.Name = "label_spritesetPointer";
+            label_spritesetPointer.Size = new System.Drawing.Size(40, 13);
+            label_spritesetPointer.TabIndex = 0;
+            label_spritesetPointer.Text = "Pointer";
             // 
             // textBox_defaultPointer
             // 
-            this.textBox_defaultPointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_defaultPointer.Location = new System.Drawing.Point(59, 35);
-            this.textBox_defaultPointer.Name = "textBox_defaultPointer";
-            this.textBox_defaultPointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_defaultPointer.TabIndex = 0;
-            this.textBox_defaultPointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_defaultPointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_defaultPointer.Location = new System.Drawing.Point(69, 40);
+            textBox_defaultPointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_defaultPointer.Multiline = false;
+            textBox_defaultPointer.Name = "textBox_defaultPointer";
+            textBox_defaultPointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_defaultPointer.ReadOnly = false;
+            textBox_defaultPointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_defaultPointer.SelectionStart = 0;
+            textBox_defaultPointer.Size = new System.Drawing.Size(76, 23);
+            textBox_defaultPointer.TabIndex = 0;
+            textBox_defaultPointer.WordWrap = true;
+            textBox_defaultPointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_defaultSpriteset
             // 
-            this.textBox_defaultSpriteset.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_defaultSpriteset.Location = new System.Drawing.Point(130, 35);
-            this.textBox_defaultSpriteset.Name = "textBox_defaultSpriteset";
-            this.textBox_defaultSpriteset.Size = new System.Drawing.Size(30, 20);
-            this.textBox_defaultSpriteset.TabIndex = 1;
-            this.textBox_defaultSpriteset.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_defaultSpriteset.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_defaultSpriteset.Location = new System.Drawing.Point(152, 40);
+            textBox_defaultSpriteset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_defaultSpriteset.Multiline = false;
+            textBox_defaultSpriteset.Name = "textBox_defaultSpriteset";
+            textBox_defaultSpriteset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_defaultSpriteset.ReadOnly = false;
+            textBox_defaultSpriteset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_defaultSpriteset.SelectionStart = 0;
+            textBox_defaultSpriteset.Size = new System.Drawing.Size(35, 23);
+            textBox_defaultSpriteset.TabIndex = 1;
+            textBox_defaultSpriteset.WordWrap = true;
+            textBox_defaultSpriteset.TextChanged += textBox_TextChanged;
             // 
             // textBox_secondEvent
             // 
-            this.textBox_secondEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_secondEvent.Location = new System.Drawing.Point(166, 87);
-            this.textBox_secondEvent.Name = "textBox_secondEvent";
-            this.textBox_secondEvent.Size = new System.Drawing.Size(30, 20);
-            this.textBox_secondEvent.TabIndex = 7;
-            this.textBox_secondEvent.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_secondEvent.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_secondEvent.Location = new System.Drawing.Point(194, 100);
+            textBox_secondEvent.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_secondEvent.Multiline = false;
+            textBox_secondEvent.Name = "textBox_secondEvent";
+            textBox_secondEvent.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_secondEvent.ReadOnly = false;
+            textBox_secondEvent.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_secondEvent.SelectionStart = 0;
+            textBox_secondEvent.Size = new System.Drawing.Size(35, 23);
+            textBox_secondEvent.TabIndex = 7;
+            textBox_secondEvent.WordWrap = true;
+            textBox_secondEvent.TextChanged += textBox_TextChanged;
             // 
             // textBox_secondPointer
             // 
-            this.textBox_secondPointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_secondPointer.Location = new System.Drawing.Point(59, 87);
-            this.textBox_secondPointer.Name = "textBox_secondPointer";
-            this.textBox_secondPointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_secondPointer.TabIndex = 5;
-            this.textBox_secondPointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_secondPointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_secondPointer.Location = new System.Drawing.Point(69, 100);
+            textBox_secondPointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_secondPointer.Multiline = false;
+            textBox_secondPointer.Name = "textBox_secondPointer";
+            textBox_secondPointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_secondPointer.ReadOnly = false;
+            textBox_secondPointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_secondPointer.SelectionStart = 0;
+            textBox_secondPointer.Size = new System.Drawing.Size(76, 23);
+            textBox_secondPointer.TabIndex = 5;
+            textBox_secondPointer.WordWrap = true;
+            textBox_secondPointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_secondSpriteset
             // 
-            this.textBox_secondSpriteset.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_secondSpriteset.Location = new System.Drawing.Point(130, 87);
-            this.textBox_secondSpriteset.Name = "textBox_secondSpriteset";
-            this.textBox_secondSpriteset.Size = new System.Drawing.Size(30, 20);
-            this.textBox_secondSpriteset.TabIndex = 6;
-            this.textBox_secondSpriteset.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_secondSpriteset.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_secondSpriteset.Location = new System.Drawing.Point(152, 100);
+            textBox_secondSpriteset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_secondSpriteset.Multiline = false;
+            textBox_secondSpriteset.Name = "textBox_secondSpriteset";
+            textBox_secondSpriteset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_secondSpriteset.ReadOnly = false;
+            textBox_secondSpriteset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_secondSpriteset.SelectionStart = 0;
+            textBox_secondSpriteset.Size = new System.Drawing.Size(35, 23);
+            textBox_secondSpriteset.TabIndex = 6;
+            textBox_secondSpriteset.WordWrap = true;
+            textBox_secondSpriteset.TextChanged += textBox_TextChanged;
             // 
             // textBox_firstEvent
             // 
-            this.textBox_firstEvent.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_firstEvent.Location = new System.Drawing.Point(166, 61);
-            this.textBox_firstEvent.Name = "textBox_firstEvent";
-            this.textBox_firstEvent.Size = new System.Drawing.Size(30, 20);
-            this.textBox_firstEvent.TabIndex = 4;
-            this.textBox_firstEvent.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_firstEvent.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_firstEvent.Location = new System.Drawing.Point(194, 70);
+            textBox_firstEvent.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_firstEvent.Multiline = false;
+            textBox_firstEvent.Name = "textBox_firstEvent";
+            textBox_firstEvent.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_firstEvent.ReadOnly = false;
+            textBox_firstEvent.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_firstEvent.SelectionStart = 0;
+            textBox_firstEvent.Size = new System.Drawing.Size(35, 23);
+            textBox_firstEvent.TabIndex = 4;
+            textBox_firstEvent.WordWrap = true;
+            textBox_firstEvent.TextChanged += textBox_TextChanged;
             // 
             // textBox_firstPointer
             // 
-            this.textBox_firstPointer.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_firstPointer.Location = new System.Drawing.Point(59, 61);
-            this.textBox_firstPointer.Name = "textBox_firstPointer";
-            this.textBox_firstPointer.Size = new System.Drawing.Size(65, 20);
-            this.textBox_firstPointer.TabIndex = 2;
-            this.textBox_firstPointer.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_firstPointer.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_firstPointer.Location = new System.Drawing.Point(69, 70);
+            textBox_firstPointer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_firstPointer.Multiline = false;
+            textBox_firstPointer.Name = "textBox_firstPointer";
+            textBox_firstPointer.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_firstPointer.ReadOnly = false;
+            textBox_firstPointer.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_firstPointer.SelectionStart = 0;
+            textBox_firstPointer.Size = new System.Drawing.Size(76, 23);
+            textBox_firstPointer.TabIndex = 2;
+            textBox_firstPointer.WordWrap = true;
+            textBox_firstPointer.TextChanged += textBox_TextChanged;
             // 
             // textBox_firstSpriteset
             // 
-            this.textBox_firstSpriteset.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_firstSpriteset.Location = new System.Drawing.Point(130, 61);
-            this.textBox_firstSpriteset.Name = "textBox_firstSpriteset";
-            this.textBox_firstSpriteset.Size = new System.Drawing.Size(30, 20);
-            this.textBox_firstSpriteset.TabIndex = 3;
-            this.textBox_firstSpriteset.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_firstSpriteset.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_firstSpriteset.Location = new System.Drawing.Point(152, 70);
+            textBox_firstSpriteset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_firstSpriteset.Multiline = false;
+            textBox_firstSpriteset.Name = "textBox_firstSpriteset";
+            textBox_firstSpriteset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_firstSpriteset.ReadOnly = false;
+            textBox_firstSpriteset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_firstSpriteset.SelectionStart = 0;
+            textBox_firstSpriteset.Size = new System.Drawing.Size(35, 23);
+            textBox_firstSpriteset.TabIndex = 3;
+            textBox_firstSpriteset.WordWrap = true;
+            textBox_firstSpriteset.TextChanged += textBox_TextChanged;
             // 
             // groupBox_misc
             // 
-            this.groupBox_misc.Controls.Add(this.label_music);
-            this.groupBox_misc.Controls.Add(this.textBox_music);
-            this.groupBox_misc.Controls.Add(this.label_mapY);
-            this.groupBox_misc.Controls.Add(this.label_mapX);
-            this.groupBox_misc.Controls.Add(this.textBox_mapX);
-            this.groupBox_misc.Controls.Add(this.textBox_mapY);
-            this.groupBox_misc.Location = new System.Drawing.Point(223, 186);
-            this.groupBox_misc.Name = "groupBox_misc";
-            this.groupBox_misc.Size = new System.Drawing.Size(92, 118);
-            this.groupBox_misc.TabIndex = 2;
-            this.groupBox_misc.TabStop = false;
-            this.groupBox_misc.Text = "Miscellaneous";
+            groupBox_misc.Controls.Add(label_music);
+            groupBox_misc.Controls.Add(textBox_music);
+            groupBox_misc.Controls.Add(label_mapY);
+            groupBox_misc.Controls.Add(label_mapX);
+            groupBox_misc.Controls.Add(textBox_mapX);
+            groupBox_misc.Controls.Add(textBox_mapY);
+            groupBox_misc.Location = new System.Drawing.Point(260, 215);
+            groupBox_misc.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_misc.Name = "groupBox_misc";
+            groupBox_misc.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_misc.Size = new System.Drawing.Size(107, 136);
+            groupBox_misc.TabIndex = 2;
+            groupBox_misc.TabStop = false;
+            groupBox_misc.Text = "Miscellaneous";
             // 
             // label_music
             // 
-            this.label_music.AutoSize = true;
-            this.label_music.Location = new System.Drawing.Point(6, 90);
-            this.label_music.Name = "label_music";
-            this.label_music.Size = new System.Drawing.Size(38, 13);
-            this.label_music.TabIndex = 0;
-            this.label_music.Text = "Music:";
+            label_music.AutoSize = true;
+            label_music.Location = new System.Drawing.Point(7, 104);
+            label_music.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_music.Name = "label_music";
+            label_music.Size = new System.Drawing.Size(42, 15);
+            label_music.TabIndex = 0;
+            label_music.Text = "Music:";
             // 
             // textBox_music
             // 
-            this.textBox_music.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_music.Location = new System.Drawing.Point(53, 87);
-            this.textBox_music.Name = "textBox_music";
-            this.textBox_music.Size = new System.Drawing.Size(30, 20);
-            this.textBox_music.TabIndex = 2;
-            this.textBox_music.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_music.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_music.Location = new System.Drawing.Point(62, 100);
+            textBox_music.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_music.Multiline = false;
+            textBox_music.Name = "textBox_music";
+            textBox_music.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_music.ReadOnly = false;
+            textBox_music.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_music.SelectionStart = 0;
+            textBox_music.Size = new System.Drawing.Size(35, 23);
+            textBox_music.TabIndex = 2;
+            textBox_music.WordWrap = true;
+            textBox_music.TextChanged += textBox_TextChanged;
             // 
             // label_mapY
             // 
-            this.label_mapY.AutoSize = true;
-            this.label_mapY.Location = new System.Drawing.Point(6, 58);
-            this.label_mapY.Name = "label_mapY";
-            this.label_mapY.Size = new System.Drawing.Size(41, 13);
-            this.label_mapY.TabIndex = 0;
-            this.label_mapY.Text = "Map Y:";
+            label_mapY.AutoSize = true;
+            label_mapY.Location = new System.Drawing.Point(7, 67);
+            label_mapY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_mapY.Name = "label_mapY";
+            label_mapY.Size = new System.Drawing.Size(44, 15);
+            label_mapY.TabIndex = 0;
+            label_mapY.Text = "Map Y:";
             // 
             // label_mapX
             // 
-            this.label_mapX.AutoSize = true;
-            this.label_mapX.Location = new System.Drawing.Point(6, 26);
-            this.label_mapX.Name = "label_mapX";
-            this.label_mapX.Size = new System.Drawing.Size(41, 13);
-            this.label_mapX.TabIndex = 0;
-            this.label_mapX.Text = "Map X:";
+            label_mapX.AutoSize = true;
+            label_mapX.Location = new System.Drawing.Point(7, 30);
+            label_mapX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_mapX.Name = "label_mapX";
+            label_mapX.Size = new System.Drawing.Size(44, 15);
+            label_mapX.TabIndex = 0;
+            label_mapX.Text = "Map X:";
             // 
             // textBox_mapX
             // 
-            this.textBox_mapX.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_mapX.Location = new System.Drawing.Point(53, 23);
-            this.textBox_mapX.Name = "textBox_mapX";
-            this.textBox_mapX.Size = new System.Drawing.Size(30, 20);
-            this.textBox_mapX.TabIndex = 0;
-            this.textBox_mapX.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_mapX.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_mapX.Location = new System.Drawing.Point(62, 27);
+            textBox_mapX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_mapX.Multiline = false;
+            textBox_mapX.Name = "textBox_mapX";
+            textBox_mapX.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_mapX.ReadOnly = false;
+            textBox_mapX.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_mapX.SelectionStart = 0;
+            textBox_mapX.Size = new System.Drawing.Size(35, 23);
+            textBox_mapX.TabIndex = 0;
+            textBox_mapX.WordWrap = true;
+            textBox_mapX.TextChanged += textBox_TextChanged;
             // 
             // textBox_mapY
             // 
-            this.textBox_mapY.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_mapY.Location = new System.Drawing.Point(53, 55);
-            this.textBox_mapY.Name = "textBox_mapY";
-            this.textBox_mapY.Size = new System.Drawing.Size(30, 20);
-            this.textBox_mapY.TabIndex = 1;
-            this.textBox_mapY.TextChanged += new System.EventHandler(this.textBox_TextChanged);
+            textBox_mapY.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_mapY.Location = new System.Drawing.Point(62, 63);
+            textBox_mapY.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_mapY.Multiline = false;
+            textBox_mapY.Name = "textBox_mapY";
+            textBox_mapY.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_mapY.ReadOnly = false;
+            textBox_mapY.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_mapY.SelectionStart = 0;
+            textBox_mapY.Size = new System.Drawing.Size(35, 23);
+            textBox_mapY.TabIndex = 1;
+            textBox_mapY.WordWrap = true;
+            textBox_mapY.TextChanged += textBox_TextChanged;
             // 
             // button_apply
             // 
-            this.button_apply.Enabled = false;
-            this.button_apply.Location = new System.Drawing.Point(159, 310);
-            this.button_apply.Name = "button_apply";
-            this.button_apply.Size = new System.Drawing.Size(75, 23);
-            this.button_apply.TabIndex = 5;
-            this.button_apply.Text = "Apply";
-            this.button_apply.UseVisualStyleBackColor = true;
-            this.button_apply.Click += new System.EventHandler(this.button_apply_Click);
+            button_apply.Enabled = false;
+            button_apply.Location = new System.Drawing.Point(186, 358);
+            button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_apply.Name = "button_apply";
+            button_apply.Size = new System.Drawing.Size(88, 27);
+            button_apply.TabIndex = 5;
+            button_apply.Text = "Apply";
+            button_apply.UseVisualStyleBackColor = true;
+            button_apply.Click += button_apply_Click;
             // 
             // button_close
             // 
-            this.button_close.Location = new System.Drawing.Point(240, 310);
-            this.button_close.Name = "button_close";
-            this.button_close.Size = new System.Drawing.Size(75, 23);
-            this.button_close.TabIndex = 6;
-            this.button_close.Text = "Close";
-            this.button_close.UseVisualStyleBackColor = true;
-            this.button_close.Click += new System.EventHandler(this.button_close_Click);
+            button_close.Location = new System.Drawing.Point(280, 358);
+            button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_close.Name = "button_close";
+            button_close.Size = new System.Drawing.Size(88, 27);
+            button_close.TabIndex = 6;
+            button_close.Text = "Close";
+            button_close.UseVisualStyleBackColor = true;
+            button_close.Click += button_close_Click;
             // 
             // label_offset
             // 
-            this.label_offset.AutoSize = true;
-            this.label_offset.Location = new System.Drawing.Point(157, 339);
-            this.label_offset.Name = "label_offset";
-            this.label_offset.Size = new System.Drawing.Size(38, 13);
-            this.label_offset.TabIndex = 0;
-            this.label_offset.Text = "Offset:";
+            label_offset.AutoSize = true;
+            label_offset.Location = new System.Drawing.Point(183, 391);
+            label_offset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_offset.Name = "label_offset";
+            label_offset.Size = new System.Drawing.Size(42, 15);
+            label_offset.TabIndex = 0;
+            label_offset.Text = "Offset:";
             // 
             // textBox_offsetVal
             // 
-            this.textBox_offsetVal.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_offsetVal.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_offsetVal.Location = new System.Drawing.Point(199, 339);
-            this.textBox_offsetVal.Name = "textBox_offsetVal";
-            this.textBox_offsetVal.ReadOnly = true;
-            this.textBox_offsetVal.Size = new System.Drawing.Size(55, 13);
-            this.textBox_offsetVal.TabIndex = 0;
-            this.textBox_offsetVal.TabStop = false;
-            this.textBox_offsetVal.Text = "000000";
+            textBox_offsetVal.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_offsetVal.Location = new System.Drawing.Point(233, 388);
+            textBox_offsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_offsetVal.Multiline = false;
+            textBox_offsetVal.Name = "textBox_offsetVal";
+            textBox_offsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_offsetVal.ReadOnly = true;
+            textBox_offsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_offsetVal.SelectionStart = 0;
+            textBox_offsetVal.Size = new System.Drawing.Size(64, 23);
+            textBox_offsetVal.TabIndex = 0;
+            textBox_offsetVal.TabStop = false;
+            textBox_offsetVal.WordWrap = true;
             // 
             // label_room
             // 
-            this.label_room.AutoSize = true;
-            this.label_room.Location = new System.Drawing.Point(12, 339);
-            this.label_room.Name = "label_room";
-            this.label_room.Size = new System.Drawing.Size(38, 13);
-            this.label_room.TabIndex = 0;
-            this.label_room.Text = "Room:";
+            label_room.AutoSize = true;
+            label_room.Location = new System.Drawing.Point(14, 391);
+            label_room.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_room.Name = "label_room";
+            label_room.Size = new System.Drawing.Size(42, 15);
+            label_room.TabIndex = 0;
+            label_room.Text = "Room:";
             // 
             // label_area
             // 
-            this.label_area.AutoSize = true;
-            this.label_area.Location = new System.Drawing.Point(12, 314);
-            this.label_area.Name = "label_area";
-            this.label_area.Size = new System.Drawing.Size(32, 13);
-            this.label_area.TabIndex = 0;
-            this.label_area.Text = "Area:";
+            label_area.AutoSize = true;
+            label_area.Location = new System.Drawing.Point(14, 362);
+            label_area.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_area.Name = "label_area";
+            label_area.Size = new System.Drawing.Size(34, 15);
+            label_area.TabIndex = 0;
+            label_area.Text = "Area:";
             // 
             // comboBox_room
             // 
-            this.comboBox_room.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_room.FormattingEnabled = true;
-            this.comboBox_room.Location = new System.Drawing.Point(55, 336);
-            this.comboBox_room.Name = "comboBox_room";
-            this.comboBox_room.Size = new System.Drawing.Size(77, 21);
-            this.comboBox_room.TabIndex = 4;
-            this.comboBox_room.SelectedIndexChanged += new System.EventHandler(this.comboBox_room_SelectedIndexChanged);
+            comboBox_room.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_room.FormattingEnabled = true;
+            comboBox_room.Location = new System.Drawing.Point(64, 388);
+            comboBox_room.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_room.Name = "comboBox_room";
+            comboBox_room.Size = new System.Drawing.Size(89, 23);
+            comboBox_room.TabIndex = 4;
+            comboBox_room.SelectedIndexChanged += comboBox_room_SelectedIndexChanged;
             // 
             // comboBox_area
             // 
-            this.comboBox_area.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_area.FormattingEnabled = true;
-            this.comboBox_area.Location = new System.Drawing.Point(55, 311);
-            this.comboBox_area.Name = "comboBox_area";
-            this.comboBox_area.Size = new System.Drawing.Size(77, 21);
-            this.comboBox_area.TabIndex = 3;
-            this.comboBox_area.SelectedIndexChanged += new System.EventHandler(this.comboBox_area_SelectedIndexChanged);
+            comboBox_area.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_area.FormattingEnabled = true;
+            comboBox_area.Location = new System.Drawing.Point(64, 359);
+            comboBox_area.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_area.Name = "comboBox_area";
+            comboBox_area.Size = new System.Drawing.Size(89, 23);
+            comboBox_area.TabIndex = 3;
+            comboBox_area.SelectedIndexChanged += comboBox_area_SelectedIndexChanged;
             // 
             // statusStrip
             // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusLabel_changes});
-            this.statusStrip.Location = new System.Drawing.Point(0, 362);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(327, 22);
-            this.statusStrip.TabIndex = 7;
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes });
+            statusStrip.Location = new System.Drawing.Point(0, 421);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip.Size = new System.Drawing.Size(382, 22);
+            statusStrip.TabIndex = 7;
             // 
             // statusLabel_changes
             // 
-            this.statusLabel_changes.Name = "statusLabel_changes";
-            this.statusLabel_changes.Size = new System.Drawing.Size(12, 17);
-            this.statusLabel_changes.Text = "-";
+            statusLabel_changes.Name = "statusLabel_changes";
+            statusLabel_changes.Size = new System.Drawing.Size(12, 17);
+            statusLabel_changes.Text = "-";
             // 
             // FormHeader
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(327, 384);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.label_room);
-            this.Controls.Add(this.label_area);
-            this.Controls.Add(this.comboBox_room);
-            this.Controls.Add(this.comboBox_area);
-            this.Controls.Add(this.textBox_offsetVal);
-            this.Controls.Add(this.label_offset);
-            this.Controls.Add(this.button_close);
-            this.Controls.Add(this.button_apply);
-            this.Controls.Add(this.groupBox_misc);
-            this.Controls.Add(this.groupBox_spritesetData);
-            this.Controls.Add(this.groupBox_BGdata);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "FormHeader";
-            this.Text = "Header Editor";
-            this.groupBox_BGdata.ResumeLayout(false);
-            this.groupBox_BGdata.PerformLayout();
-            this.groupBox_spritesetData.ResumeLayout(false);
-            this.groupBox_spritesetData.PerformLayout();
-            this.groupBox_misc.ResumeLayout(false);
-            this.groupBox_misc.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(382, 443);
+            Controls.Add(statusStrip);
+            Controls.Add(label_room);
+            Controls.Add(label_area);
+            Controls.Add(comboBox_room);
+            Controls.Add(comboBox_area);
+            Controls.Add(textBox_offsetVal);
+            Controls.Add(label_offset);
+            Controls.Add(button_close);
+            Controls.Add(button_apply);
+            Controls.Add(groupBox_misc);
+            Controls.Add(groupBox_spritesetData);
+            Controls.Add(groupBox_BGdata);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "FormHeader";
+            Text = "Header Editor";
+            groupBox_BGdata.ResumeLayout(false);
+            groupBox_BGdata.PerformLayout();
+            groupBox_spritesetData.ResumeLayout(false);
+            groupBox_spritesetData.PerformLayout();
+            groupBox_misc.ResumeLayout(false);
+            groupBox_misc.PerformLayout();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/mage/Editors/FormHeader.cs
+++ b/mage/Editors/FormHeader.cs
@@ -184,7 +184,7 @@ namespace mage
                 byte effect = Hex.ToByte(textBox_effect.Text);
                 byte effectY = Hex.ToByte(textBox_effectYpos.Text);
                 ushort music = Hex.ToUshort(textBox_music.Text);
-     
+
                 int offset = romStream.ReadPtr(Version.AreaHeaderOffset + a * 4) + (r * 0x3C);
 
                 // write all values

--- a/mage/Editors/FormHeader.resx
+++ b/mage/Editors/FormHeader.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>58</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAEBAAAAAAGABoAwAAJgAAACAgAAAAABgAqAwAAI4DAAAoAAAAEAAAACAAAAABABgAAAAAAAAD

--- a/mage/Editors/FormMinimap.Designer.cs
+++ b/mage/Editors/FormMinimap.Designer.cs
@@ -64,6 +64,7 @@
             statusStrip_exportRaw = new System.Windows.Forms.ToolStripMenuItem();
             statusStrip_exportImage = new System.Windows.Forms.ToolStripMenuItem();
             gfxView_map = new GfxView();
+            button_generate = new System.Windows.Forms.Button();
             groupBox_map.SuspendLayout();
             groupBox_selection.SuspendLayout();
             panel_black.SuspendLayout();
@@ -188,7 +189,7 @@
             button_apply.Location = new System.Drawing.Point(882, 121);
             button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_apply.Name = "button_apply";
-            button_apply.Size = new System.Drawing.Size(88, 27);
+            button_apply.Size = new System.Drawing.Size(86, 27);
             button_apply.TabIndex = 4;
             button_apply.Text = "Apply";
             button_apply.UseVisualStyleBackColor = true;
@@ -196,7 +197,7 @@
             // 
             // button_close
             // 
-            button_close.Location = new System.Drawing.Point(882, 155);
+            button_close.Location = new System.Drawing.Point(786, 121);
             button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_close.Name = "button_close";
             button_close.Size = new System.Drawing.Size(88, 27);
@@ -270,7 +271,7 @@
             // 
             // button_editGFX
             // 
-            button_editGFX.Location = new System.Drawing.Point(127, 21);
+            button_editGFX.Location = new System.Drawing.Point(217, 19);
             button_editGFX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_editGFX.Name = "button_editGFX";
             button_editGFX.Size = new System.Drawing.Size(82, 27);
@@ -284,7 +285,7 @@
             panel_squares.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             panel_squares.AutoScroll = true;
             panel_squares.Controls.Add(gfxView_squares);
-            panel_squares.Location = new System.Drawing.Point(619, 188);
+            panel_squares.Location = new System.Drawing.Point(619, 219);
             panel_squares.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             panel_squares.Name = "panel_squares";
             panel_squares.Size = new System.Drawing.Size(351, 347);
@@ -308,11 +309,11 @@
             groupBox_tiles.Controls.Add(button_editGFX);
             groupBox_tiles.Controls.Add(comboBox_palette);
             groupBox_tiles.Controls.Add(label_palette);
-            groupBox_tiles.Location = new System.Drawing.Point(619, 121);
+            groupBox_tiles.Location = new System.Drawing.Point(619, 154);
             groupBox_tiles.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_tiles.Name = "groupBox_tiles";
             groupBox_tiles.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox_tiles.Size = new System.Drawing.Size(250, 59);
+            groupBox_tiles.Size = new System.Drawing.Size(349, 59);
             groupBox_tiles.TabIndex = 9;
             groupBox_tiles.TabStop = false;
             groupBox_tiles.Text = "Tiles";
@@ -320,7 +321,7 @@
             // button_bgColor
             // 
             button_bgColor.Image = Properties.Resources.button_bg_color;
-            button_bgColor.Location = new System.Drawing.Point(216, 21);
+            button_bgColor.Location = new System.Drawing.Point(313, 19);
             button_bgColor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_bgColor.Name = "button_bgColor";
             button_bgColor.Size = new System.Drawing.Size(27, 27);
@@ -420,11 +421,23 @@
             gfxView_map.MouseDown += gfxView_map_MouseDown;
             gfxView_map.MouseMove += gfxView_map_MouseMove;
             // 
+            // button_generate
+            // 
+            button_generate.Location = new System.Drawing.Point(619, 121);
+            button_generate.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_generate.Name = "button_generate";
+            button_generate.Size = new System.Drawing.Size(159, 27);
+            button_generate.TabIndex = 12;
+            button_generate.Text = "Generate";
+            button_generate.UseVisualStyleBackColor = true;
+            button_generate.Click += button_generate_Click;
+            // 
             // FormMinimap
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             ClientSize = new System.Drawing.Size(983, 643);
+            Controls.Add(button_generate);
             Controls.Add(statusStrip);
             Controls.Add(groupBox_tiles);
             Controls.Add(panel_squares);
@@ -490,5 +503,6 @@
         private System.Windows.Forms.ToolStripMenuItem statusStrip_importRaw;
         private System.Windows.Forms.ToolStripMenuItem statusStrip_exportRaw;
         private System.Windows.Forms.ToolStripStatusLabel statusLabel_changes;
+        private System.Windows.Forms.Button button_generate;
     }
 }

--- a/mage/Editors/FormMinimap.cs
+++ b/mage/Editors/FormMinimap.cs
@@ -462,5 +462,47 @@ namespace mage
                 offset += 0x3C;
             }
         }
+
+        private void button_generate_Click(object sender, EventArgs e)
+        {
+            //clearing old map
+            for (int i = 0; i < 32; i++)
+            {
+                for (int j = 0; j < 32; j++)
+                {
+                    selSquare = 0x140;
+                    mPos = new Point(i, j);
+                    SetNewSquare();
+                }
+            }
+
+            selSquare = 0x87;
+
+            //Loop through each room and room header in the current selected area
+            byte area = (byte)comboBox_area.SelectedIndex;
+            for (int i = 0; i < Version.RoomsPerArea[(byte)comboBox_area.SelectedIndex]; i++)
+            {
+                //Create Room Object, read map coordinates
+                Room rm = new Room(area, i);
+                int width = rm.Width / 0xF;
+                int height = rm.Height / 0xA;
+
+                int offset = romStream.ReadPtr(Version.AreaHeaderOffset + area * 4) + (i * 0x3C);
+                byte mapX = romStream.Read8(offset + 0x35);
+                byte mapY = romStream.Read8(offset + 0x36);
+
+                //place map tile
+                for (int j = 0; j < width; j++)
+                {
+                    for (int k = 0; k < height; k++)
+                    {
+                        mPos = new Point(mapX + j, mapY + k);
+                        SetNewSquare();
+                    }
+                }
+            }
+
+            gfxView_map.Invalidate();
+        }
     }
 }

--- a/mage/Editors/FormMinimap.cs
+++ b/mage/Editors/FormMinimap.cs
@@ -284,6 +284,13 @@ namespace mage
 
             mPos = new Point(x, y);
 
+            if (e.Button == MouseButtons.Left && selSquare != -1)
+            {
+                SetNewSquare();
+                Rectangle r = new Rectangle(mPos.X * 16, mPos.Y * 16, 16, 16);
+                gfxView_map.Invalidate(r);
+            }
+
             // draw red rectangle
             Rectangle rect = gfxView_map.redRect;
             gfxView_map.MoveRed(x, y);

--- a/mage/Editors/FormMinimap.cs
+++ b/mage/Editors/FormMinimap.cs
@@ -159,6 +159,8 @@ namespace mage
 
         private void LoadMinimap()
         {
+            button_generate.Enabled = comboBox_area.SelectedIndex <= 6;
+
             byte areaID = (byte)comboBox_area.SelectedIndex;
             try
             {
@@ -465,6 +467,8 @@ namespace mage
 
         private void button_generate_Click(object sender, EventArgs e)
         {
+            comboBox_type.SelectedIndex = 1;
+
             //clearing old map
             for (int i = 0; i < 32; i++)
             {

--- a/mage/Editors/FormPalette.Designer.cs
+++ b/mage/Editors/FormPalette.Designer.cs
@@ -29,536 +29,571 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormPalette));
-            this.pictureBox_palette = new System.Windows.Forms.PictureBox();
-            this.pictureBox_chosenColor = new System.Windows.Forms.PictureBox();
-            this.comboBox_tileset = new mage.Theming.CustomControls.FlatComboBox();
-            this.groupBox_offset = new System.Windows.Forms.GroupBox();
-            this.button_minus = new System.Windows.Forms.Button();
-            this.button_plus = new System.Windows.Forms.Button();
-            this.button_go = new System.Windows.Forms.Button();
-            this.numericUpDown_rows = new mage.Theming.CustomControls.FlatNumericUpDown();
-            this.label_numOfRows = new System.Windows.Forms.Label();
-            this.textBox_offset = new mage.Theming.CustomControls.FlatTextBox();
-            this.comboBox_sprite = new mage.Theming.CustomControls.FlatComboBox();
-            this.label_red = new System.Windows.Forms.Label();
-            this.label_green = new System.Windows.Forms.Label();
-            this.label_blue = new System.Windows.Forms.Label();
-            this.numericUpDown_red = new mage.Theming.CustomControls.FlatNumericUpDown();
-            this.numericUpDown_green = new mage.Theming.CustomControls.FlatNumericUpDown();
-            this.numericUpDown_blue = new mage.Theming.CustomControls.FlatNumericUpDown();
-            this.button_apply = new System.Windows.Forms.Button();
-            this.button_close = new System.Windows.Forms.Button();
-            this.label_15bit = new System.Windows.Forms.Label();
-            this.label_15bitVal = new System.Windows.Forms.Label();
-            this.pictureBox_red = new System.Windows.Forms.PictureBox();
-            this.pictureBox_green = new System.Windows.Forms.PictureBox();
-            this.pictureBox_blue = new System.Windows.Forms.PictureBox();
-            this.groupBox_color = new System.Windows.Forms.GroupBox();
-            this.groupBox_shortcuts = new System.Windows.Forms.GroupBox();
-            this.label_sprite = new System.Windows.Forms.Label();
-            this.label_tileset = new System.Windows.Forms.Label();
-            this.label_24bitVal = new System.Windows.Forms.Label();
-            this.label_24bit = new System.Windows.Forms.Label();
-            this.groupBox_info = new System.Windows.Forms.GroupBox();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusStrip_spring = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusStrip_import = new System.Windows.Forms.ToolStripDropDownButton();
-            this.statusStrip_importRaw = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip_importTLP = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip_importYY = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip_export = new System.Windows.Forms.ToolStripDropDownButton();
-            this.statusStrip_exportRaw = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip_exportTLP = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip_exportYY = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_palette)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_chosenColor)).BeginInit();
-            this.groupBox_offset.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_rows)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_red)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_green)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_blue)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_red)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_green)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_blue)).BeginInit();
-            this.groupBox_color.SuspendLayout();
-            this.groupBox_shortcuts.SuspendLayout();
-            this.groupBox_info.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            this.SuspendLayout();
+            pictureBox_palette = new System.Windows.Forms.PictureBox();
+            pictureBox_chosenColor = new System.Windows.Forms.PictureBox();
+            comboBox_tileset = new Theming.CustomControls.FlatComboBox();
+            groupBox_offset = new System.Windows.Forms.GroupBox();
+            button_minus = new System.Windows.Forms.Button();
+            button_plus = new System.Windows.Forms.Button();
+            button_go = new System.Windows.Forms.Button();
+            numericUpDown_rows = new Theming.CustomControls.FlatNumericUpDown();
+            label_numOfRows = new System.Windows.Forms.Label();
+            textBox_offset = new Theming.CustomControls.FlatTextBox();
+            comboBox_sprite = new Theming.CustomControls.FlatComboBox();
+            label_red = new System.Windows.Forms.Label();
+            label_green = new System.Windows.Forms.Label();
+            label_blue = new System.Windows.Forms.Label();
+            numericUpDown_red = new Theming.CustomControls.FlatNumericUpDown();
+            numericUpDown_green = new Theming.CustomControls.FlatNumericUpDown();
+            numericUpDown_blue = new Theming.CustomControls.FlatNumericUpDown();
+            button_apply = new System.Windows.Forms.Button();
+            button_close = new System.Windows.Forms.Button();
+            label_15bit = new System.Windows.Forms.Label();
+            label_15bitVal = new System.Windows.Forms.Label();
+            pictureBox_red = new System.Windows.Forms.PictureBox();
+            pictureBox_green = new System.Windows.Forms.PictureBox();
+            pictureBox_blue = new System.Windows.Forms.PictureBox();
+            groupBox_color = new System.Windows.Forms.GroupBox();
+            label_html_color = new System.Windows.Forms.Label();
+            textBox_html_color = new Theming.CustomControls.FlatTextBox();
+            groupBox_shortcuts = new System.Windows.Forms.GroupBox();
+            label_sprite = new System.Windows.Forms.Label();
+            label_tileset = new System.Windows.Forms.Label();
+            label_24bitVal = new System.Windows.Forms.Label();
+            label_24bit = new System.Windows.Forms.Label();
+            groupBox_info = new System.Windows.Forms.GroupBox();
+            statusStrip = new System.Windows.Forms.StatusStrip();
+            statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
+            statusStrip_spring = new System.Windows.Forms.ToolStripStatusLabel();
+            statusStrip_import = new System.Windows.Forms.ToolStripDropDownButton();
+            statusStrip_importRaw = new System.Windows.Forms.ToolStripMenuItem();
+            statusStrip_importTLP = new System.Windows.Forms.ToolStripMenuItem();
+            statusStrip_importYY = new System.Windows.Forms.ToolStripMenuItem();
+            statusStrip_export = new System.Windows.Forms.ToolStripDropDownButton();
+            statusStrip_exportRaw = new System.Windows.Forms.ToolStripMenuItem();
+            statusStrip_exportTLP = new System.Windows.Forms.ToolStripMenuItem();
+            statusStrip_exportYY = new System.Windows.Forms.ToolStripMenuItem();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_palette).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_chosenColor).BeginInit();
+            groupBox_offset.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_rows).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_red).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_green).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_blue).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_red).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_green).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_blue).BeginInit();
+            groupBox_color.SuspendLayout();
+            groupBox_shortcuts.SuspendLayout();
+            groupBox_info.SuspendLayout();
+            statusStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // pictureBox_palette
             // 
-            this.pictureBox_palette.Location = new System.Drawing.Point(12, 12);
-            this.pictureBox_palette.Name = "pictureBox_palette";
-            this.pictureBox_palette.Size = new System.Drawing.Size(273, 273);
-            this.pictureBox_palette.TabIndex = 0;
-            this.pictureBox_palette.TabStop = false;
-            this.pictureBox_palette.MouseClick += new System.Windows.Forms.MouseEventHandler(this.pictureBox_palette_MouseClick);
+            pictureBox_palette.Location = new System.Drawing.Point(14, 14);
+            pictureBox_palette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_palette.Name = "pictureBox_palette";
+            pictureBox_palette.Size = new System.Drawing.Size(318, 315);
+            pictureBox_palette.TabIndex = 0;
+            pictureBox_palette.TabStop = false;
+            pictureBox_palette.MouseClick += pictureBox_palette_MouseClick;
             // 
             // pictureBox_chosenColor
             // 
-            this.pictureBox_chosenColor.Location = new System.Drawing.Point(6, 18);
-            this.pictureBox_chosenColor.Name = "pictureBox_chosenColor";
-            this.pictureBox_chosenColor.Size = new System.Drawing.Size(30, 30);
-            this.pictureBox_chosenColor.TabIndex = 2;
-            this.pictureBox_chosenColor.TabStop = false;
+            pictureBox_chosenColor.Location = new System.Drawing.Point(7, 21);
+            pictureBox_chosenColor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_chosenColor.Name = "pictureBox_chosenColor";
+            pictureBox_chosenColor.Size = new System.Drawing.Size(35, 35);
+            pictureBox_chosenColor.TabIndex = 2;
+            pictureBox_chosenColor.TabStop = false;
             // 
             // comboBox_tileset
             // 
-            this.comboBox_tileset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_tileset.FormattingEnabled = true;
-            this.comboBox_tileset.Location = new System.Drawing.Point(53, 19);
-            this.comboBox_tileset.Name = "comboBox_tileset";
-            this.comboBox_tileset.Size = new System.Drawing.Size(45, 21);
-            this.comboBox_tileset.TabIndex = 0;
-            this.comboBox_tileset.SelectedIndexChanged += new System.EventHandler(this.comboBox_tileset_SelectedIndexChanged);
+            comboBox_tileset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_tileset.FormattingEnabled = true;
+            comboBox_tileset.Location = new System.Drawing.Point(62, 22);
+            comboBox_tileset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_tileset.Name = "comboBox_tileset";
+            comboBox_tileset.Size = new System.Drawing.Size(52, 23);
+            comboBox_tileset.TabIndex = 0;
+            comboBox_tileset.SelectedIndexChanged += comboBox_tileset_SelectedIndexChanged;
             // 
             // groupBox_offset
             // 
-            this.groupBox_offset.Controls.Add(this.button_minus);
-            this.groupBox_offset.Controls.Add(this.button_plus);
-            this.groupBox_offset.Controls.Add(this.button_go);
-            this.groupBox_offset.Controls.Add(this.numericUpDown_rows);
-            this.groupBox_offset.Controls.Add(this.label_numOfRows);
-            this.groupBox_offset.Controls.Add(this.textBox_offset);
-            this.groupBox_offset.Location = new System.Drawing.Point(291, 12);
-            this.groupBox_offset.Name = "groupBox_offset";
-            this.groupBox_offset.Size = new System.Drawing.Size(155, 73);
-            this.groupBox_offset.TabIndex = 0;
-            this.groupBox_offset.TabStop = false;
-            this.groupBox_offset.Text = "Offset";
+            groupBox_offset.Controls.Add(button_minus);
+            groupBox_offset.Controls.Add(button_plus);
+            groupBox_offset.Controls.Add(button_go);
+            groupBox_offset.Controls.Add(numericUpDown_rows);
+            groupBox_offset.Controls.Add(label_numOfRows);
+            groupBox_offset.Controls.Add(textBox_offset);
+            groupBox_offset.Location = new System.Drawing.Point(340, 14);
+            groupBox_offset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_offset.Name = "groupBox_offset";
+            groupBox_offset.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_offset.Size = new System.Drawing.Size(181, 84);
+            groupBox_offset.TabIndex = 0;
+            groupBox_offset.TabStop = false;
+            groupBox_offset.Text = "Offset";
             // 
             // button_minus
             // 
-            this.button_minus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_minus.Location = new System.Drawing.Point(34, 43);
-            this.button_minus.Name = "button_minus";
-            this.button_minus.Size = new System.Drawing.Size(22, 22);
-            this.button_minus.TabIndex = 3;
-            this.button_minus.Text = "-";
-            this.button_minus.UseVisualStyleBackColor = true;
-            this.button_minus.Click += new System.EventHandler(this.button_minus_Click);
+            button_minus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            button_minus.Location = new System.Drawing.Point(40, 50);
+            button_minus.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_minus.Name = "button_minus";
+            button_minus.Size = new System.Drawing.Size(26, 25);
+            button_minus.TabIndex = 3;
+            button_minus.Text = "-";
+            button_minus.UseVisualStyleBackColor = true;
+            button_minus.Click += button_minus_Click;
             // 
             // button_plus
             // 
-            this.button_plus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button_plus.Location = new System.Drawing.Point(6, 43);
-            this.button_plus.Name = "button_plus";
-            this.button_plus.Size = new System.Drawing.Size(22, 22);
-            this.button_plus.TabIndex = 2;
-            this.button_plus.Text = "+";
-            this.button_plus.UseVisualStyleBackColor = true;
-            this.button_plus.Click += new System.EventHandler(this.button_plus_Click);
+            button_plus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            button_plus.Location = new System.Drawing.Point(7, 50);
+            button_plus.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_plus.Name = "button_plus";
+            button_plus.Size = new System.Drawing.Size(26, 25);
+            button_plus.TabIndex = 2;
+            button_plus.Text = "+";
+            button_plus.UseVisualStyleBackColor = true;
+            button_plus.Click += button_plus_Click;
             // 
             // button_go
             // 
-            this.button_go.Location = new System.Drawing.Point(92, 18);
-            this.button_go.Name = "button_go";
-            this.button_go.Size = new System.Drawing.Size(55, 22);
-            this.button_go.TabIndex = 1;
-            this.button_go.Text = "Go";
-            this.button_go.UseVisualStyleBackColor = true;
-            this.button_go.Click += new System.EventHandler(this.button_go_Click);
+            button_go.Location = new System.Drawing.Point(107, 21);
+            button_go.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_go.Name = "button_go";
+            button_go.Size = new System.Drawing.Size(64, 25);
+            button_go.TabIndex = 1;
+            button_go.Text = "Go";
+            button_go.UseVisualStyleBackColor = true;
+            button_go.Click += button_go_Click;
             // 
             // numericUpDown_rows
             // 
-            this.numericUpDown_rows.Hexadecimal = true;
-            this.numericUpDown_rows.Location = new System.Drawing.Point(104, 45);
-            this.numericUpDown_rows.Maximum = new decimal(new int[] {
-            16,
-            0,
-            0,
-            0});
-            this.numericUpDown_rows.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numericUpDown_rows.Name = "numericUpDown_rows";
-            this.numericUpDown_rows.Size = new System.Drawing.Size(42, 20);
-            this.numericUpDown_rows.TabIndex = 4;
-            this.numericUpDown_rows.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            numericUpDown_rows.Hexadecimal = true;
+            numericUpDown_rows.Location = new System.Drawing.Point(121, 52);
+            numericUpDown_rows.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown_rows.Maximum = new decimal(new int[] { 16, 0, 0, 0 });
+            numericUpDown_rows.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numericUpDown_rows.Name = "numericUpDown_rows";
+            numericUpDown_rows.Size = new System.Drawing.Size(49, 23);
+            numericUpDown_rows.TabIndex = 4;
+            numericUpDown_rows.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // label_numOfRows
             // 
-            this.label_numOfRows.AutoSize = true;
-            this.label_numOfRows.Location = new System.Drawing.Point(64, 47);
-            this.label_numOfRows.Name = "label_numOfRows";
-            this.label_numOfRows.Size = new System.Drawing.Size(37, 13);
-            this.label_numOfRows.TabIndex = 0;
-            this.label_numOfRows.Text = "Rows:";
+            label_numOfRows.AutoSize = true;
+            label_numOfRows.Location = new System.Drawing.Point(75, 54);
+            label_numOfRows.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_numOfRows.Name = "label_numOfRows";
+            label_numOfRows.Size = new System.Drawing.Size(38, 15);
+            label_numOfRows.TabIndex = 0;
+            label_numOfRows.Text = "Rows:";
             // 
             // textBox_offset
             // 
-            this.textBox_offset.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(188)))), ((int)(((byte)(188)))), ((int)(((byte)(188)))));
-            this.textBox_offset.Location = new System.Drawing.Point(6, 19);
-            this.textBox_offset.Name = "textBox_offset";
-            this.textBox_offset.Size = new System.Drawing.Size(80, 20);
-            this.textBox_offset.TabIndex = 0;
+            textBox_offset.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_offset.Location = new System.Drawing.Point(7, 22);
+            textBox_offset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_offset.Multiline = false;
+            textBox_offset.Name = "textBox_offset";
+            textBox_offset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_offset.ReadOnly = false;
+            textBox_offset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_offset.SelectionStart = 0;
+            textBox_offset.Size = new System.Drawing.Size(93, 23);
+            textBox_offset.TabIndex = 0;
+            textBox_offset.WordWrap = true;
             // 
             // comboBox_sprite
             // 
-            this.comboBox_sprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_sprite.FormattingEnabled = true;
-            this.comboBox_sprite.Location = new System.Drawing.Point(53, 46);
-            this.comboBox_sprite.Name = "comboBox_sprite";
-            this.comboBox_sprite.Size = new System.Drawing.Size(45, 21);
-            this.comboBox_sprite.TabIndex = 1;
-            this.comboBox_sprite.SelectedIndexChanged += new System.EventHandler(this.comboBox_sprite_SelectedIndexChanged);
+            comboBox_sprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_sprite.FormattingEnabled = true;
+            comboBox_sprite.Location = new System.Drawing.Point(62, 53);
+            comboBox_sprite.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_sprite.Name = "comboBox_sprite";
+            comboBox_sprite.Size = new System.Drawing.Size(52, 23);
+            comboBox_sprite.TabIndex = 1;
+            comboBox_sprite.SelectedIndexChanged += comboBox_sprite_SelectedIndexChanged;
             // 
             // label_red
             // 
-            this.label_red.AutoSize = true;
-            this.label_red.Location = new System.Drawing.Point(6, 21);
-            this.label_red.Name = "label_red";
-            this.label_red.Size = new System.Drawing.Size(30, 13);
-            this.label_red.TabIndex = 0;
-            this.label_red.Text = "Red:";
+            label_red.AutoSize = true;
+            label_red.Location = new System.Drawing.Point(7, 24);
+            label_red.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_red.Name = "label_red";
+            label_red.Size = new System.Drawing.Size(30, 15);
+            label_red.TabIndex = 0;
+            label_red.Text = "Red:";
             // 
             // label_green
             // 
-            this.label_green.AutoSize = true;
-            this.label_green.Location = new System.Drawing.Point(6, 50);
-            this.label_green.Name = "label_green";
-            this.label_green.Size = new System.Drawing.Size(39, 13);
-            this.label_green.TabIndex = 0;
-            this.label_green.Text = "Green:";
+            label_green.AutoSize = true;
+            label_green.Location = new System.Drawing.Point(7, 58);
+            label_green.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_green.Name = "label_green";
+            label_green.Size = new System.Drawing.Size(41, 15);
+            label_green.TabIndex = 0;
+            label_green.Text = "Green:";
             // 
             // label_blue
             // 
-            this.label_blue.AutoSize = true;
-            this.label_blue.Location = new System.Drawing.Point(6, 79);
-            this.label_blue.Name = "label_blue";
-            this.label_blue.Size = new System.Drawing.Size(31, 13);
-            this.label_blue.TabIndex = 0;
-            this.label_blue.Text = "Blue:";
+            label_blue.AutoSize = true;
+            label_blue.Location = new System.Drawing.Point(7, 91);
+            label_blue.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_blue.Name = "label_blue";
+            label_blue.Size = new System.Drawing.Size(33, 15);
+            label_blue.TabIndex = 0;
+            label_blue.Text = "Blue:";
             // 
             // numericUpDown_red
             // 
-            this.numericUpDown_red.Hexadecimal = true;
-            this.numericUpDown_red.Location = new System.Drawing.Point(49, 19);
-            this.numericUpDown_red.Maximum = new decimal(new int[] {
-            31,
-            0,
-            0,
-            0});
-            this.numericUpDown_red.Name = "numericUpDown_red";
-            this.numericUpDown_red.Size = new System.Drawing.Size(40, 20);
-            this.numericUpDown_red.TabIndex = 0;
-            this.numericUpDown_red.ValueChanged += new System.EventHandler(this.numericUpDown_red_ValueChanged);
+            numericUpDown_red.Hexadecimal = true;
+            numericUpDown_red.Location = new System.Drawing.Point(57, 22);
+            numericUpDown_red.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown_red.Maximum = new decimal(new int[] { 31, 0, 0, 0 });
+            numericUpDown_red.Name = "numericUpDown_red";
+            numericUpDown_red.Size = new System.Drawing.Size(47, 23);
+            numericUpDown_red.TabIndex = 0;
+            numericUpDown_red.ValueChanged += numericUpDown_red_ValueChanged;
             // 
             // numericUpDown_green
             // 
-            this.numericUpDown_green.Hexadecimal = true;
-            this.numericUpDown_green.Location = new System.Drawing.Point(49, 48);
-            this.numericUpDown_green.Maximum = new decimal(new int[] {
-            31,
-            0,
-            0,
-            0});
-            this.numericUpDown_green.Name = "numericUpDown_green";
-            this.numericUpDown_green.Size = new System.Drawing.Size(40, 20);
-            this.numericUpDown_green.TabIndex = 1;
-            this.numericUpDown_green.ValueChanged += new System.EventHandler(this.numericUpDown_green_ValueChanged);
+            numericUpDown_green.Hexadecimal = true;
+            numericUpDown_green.Location = new System.Drawing.Point(57, 55);
+            numericUpDown_green.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown_green.Maximum = new decimal(new int[] { 31, 0, 0, 0 });
+            numericUpDown_green.Name = "numericUpDown_green";
+            numericUpDown_green.Size = new System.Drawing.Size(47, 23);
+            numericUpDown_green.TabIndex = 1;
+            numericUpDown_green.ValueChanged += numericUpDown_green_ValueChanged;
             // 
             // numericUpDown_blue
             // 
-            this.numericUpDown_blue.Hexadecimal = true;
-            this.numericUpDown_blue.Location = new System.Drawing.Point(49, 77);
-            this.numericUpDown_blue.Maximum = new decimal(new int[] {
-            31,
-            0,
-            0,
-            0});
-            this.numericUpDown_blue.Name = "numericUpDown_blue";
-            this.numericUpDown_blue.Size = new System.Drawing.Size(40, 20);
-            this.numericUpDown_blue.TabIndex = 2;
-            this.numericUpDown_blue.ValueChanged += new System.EventHandler(this.numericUpDown_blue_ValueChanged);
+            numericUpDown_blue.Hexadecimal = true;
+            numericUpDown_blue.Location = new System.Drawing.Point(57, 89);
+            numericUpDown_blue.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown_blue.Maximum = new decimal(new int[] { 31, 0, 0, 0 });
+            numericUpDown_blue.Name = "numericUpDown_blue";
+            numericUpDown_blue.Size = new System.Drawing.Size(47, 23);
+            numericUpDown_blue.TabIndex = 2;
+            numericUpDown_blue.ValueChanged += numericUpDown_blue_ValueChanged;
             // 
             // button_apply
             // 
-            this.button_apply.Enabled = false;
-            this.button_apply.Location = new System.Drawing.Point(451, 211);
-            this.button_apply.Name = "button_apply";
-            this.button_apply.Size = new System.Drawing.Size(70, 23);
-            this.button_apply.TabIndex = 3;
-            this.button_apply.Text = "Apply";
-            this.button_apply.UseVisualStyleBackColor = true;
-            this.button_apply.Click += new System.EventHandler(this.button_apply_Click);
+            button_apply.Enabled = false;
+            button_apply.Location = new System.Drawing.Point(527, 271);
+            button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_apply.Name = "button_apply";
+            button_apply.Size = new System.Drawing.Size(82, 27);
+            button_apply.TabIndex = 3;
+            button_apply.Text = "Apply";
+            button_apply.UseVisualStyleBackColor = true;
+            button_apply.Click += button_apply_Click;
             // 
             // button_close
             // 
-            this.button_close.Location = new System.Drawing.Point(451, 239);
-            this.button_close.Name = "button_close";
-            this.button_close.Size = new System.Drawing.Size(70, 23);
-            this.button_close.TabIndex = 4;
-            this.button_close.Text = "Close";
-            this.button_close.UseVisualStyleBackColor = true;
-            this.button_close.Click += new System.EventHandler(this.button_close_Click);
+            button_close.Location = new System.Drawing.Point(527, 304);
+            button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_close.Name = "button_close";
+            button_close.Size = new System.Drawing.Size(82, 27);
+            button_close.TabIndex = 4;
+            button_close.Text = "Close";
+            button_close.UseVisualStyleBackColor = true;
+            button_close.Click += button_close_Click;
             // 
             // label_15bit
             // 
-            this.label_15bit.AutoSize = true;
-            this.label_15bit.Location = new System.Drawing.Point(40, 18);
-            this.label_15bit.Name = "label_15bit";
-            this.label_15bit.Size = new System.Drawing.Size(36, 13);
-            this.label_15bit.TabIndex = 18;
-            this.label_15bit.Text = "15-bit:";
+            label_15bit.AutoSize = true;
+            label_15bit.Location = new System.Drawing.Point(47, 21);
+            label_15bit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_15bit.Name = "label_15bit";
+            label_15bit.Size = new System.Drawing.Size(41, 15);
+            label_15bit.TabIndex = 18;
+            label_15bit.Text = "15-bit:";
             // 
             // label_15bitVal
             // 
-            this.label_15bitVal.AutoSize = true;
-            this.label_15bitVal.Location = new System.Drawing.Point(76, 18);
-            this.label_15bitVal.Name = "label_15bitVal";
-            this.label_15bitVal.Size = new System.Drawing.Size(42, 13);
-            this.label_15bitVal.TabIndex = 19;
-            this.label_15bitVal.Text = "0x0000";
+            label_15bitVal.AutoSize = true;
+            label_15bitVal.Location = new System.Drawing.Point(89, 21);
+            label_15bitVal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_15bitVal.Name = "label_15bitVal";
+            label_15bitVal.Size = new System.Drawing.Size(43, 15);
+            label_15bitVal.TabIndex = 19;
+            label_15bitVal.Text = "0x0000";
             // 
             // pictureBox_red
             // 
-            this.pictureBox_red.Location = new System.Drawing.Point(98, 19);
-            this.pictureBox_red.Name = "pictureBox_red";
-            this.pictureBox_red.Size = new System.Drawing.Size(128, 20);
-            this.pictureBox_red.TabIndex = 21;
-            this.pictureBox_red.TabStop = false;
-            this.pictureBox_red.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pictureBox_red_MouseDown);
-            this.pictureBox_red.MouseMove += new System.Windows.Forms.MouseEventHandler(this.pictureBox_red_MouseMove);
+            pictureBox_red.Location = new System.Drawing.Point(114, 22);
+            pictureBox_red.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_red.Name = "pictureBox_red";
+            pictureBox_red.Size = new System.Drawing.Size(149, 23);
+            pictureBox_red.TabIndex = 21;
+            pictureBox_red.TabStop = false;
+            pictureBox_red.MouseDown += pictureBox_red_MouseDown;
+            pictureBox_red.MouseMove += pictureBox_red_MouseMove;
             // 
             // pictureBox_green
             // 
-            this.pictureBox_green.Location = new System.Drawing.Point(98, 48);
-            this.pictureBox_green.Name = "pictureBox_green";
-            this.pictureBox_green.Size = new System.Drawing.Size(128, 20);
-            this.pictureBox_green.TabIndex = 22;
-            this.pictureBox_green.TabStop = false;
-            this.pictureBox_green.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pictureBox_green_MouseDown);
-            this.pictureBox_green.MouseMove += new System.Windows.Forms.MouseEventHandler(this.pictureBox_green_MouseMove);
+            pictureBox_green.Location = new System.Drawing.Point(114, 55);
+            pictureBox_green.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_green.Name = "pictureBox_green";
+            pictureBox_green.Size = new System.Drawing.Size(149, 23);
+            pictureBox_green.TabIndex = 22;
+            pictureBox_green.TabStop = false;
+            pictureBox_green.MouseDown += pictureBox_green_MouseDown;
+            pictureBox_green.MouseMove += pictureBox_green_MouseMove;
             // 
             // pictureBox_blue
             // 
-            this.pictureBox_blue.Location = new System.Drawing.Point(98, 77);
-            this.pictureBox_blue.Name = "pictureBox_blue";
-            this.pictureBox_blue.Size = new System.Drawing.Size(128, 20);
-            this.pictureBox_blue.TabIndex = 23;
-            this.pictureBox_blue.TabStop = false;
-            this.pictureBox_blue.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pictureBox_blue_MouseDown);
-            this.pictureBox_blue.MouseMove += new System.Windows.Forms.MouseEventHandler(this.pictureBox_blue_MouseMove);
+            pictureBox_blue.Location = new System.Drawing.Point(114, 89);
+            pictureBox_blue.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_blue.Name = "pictureBox_blue";
+            pictureBox_blue.Size = new System.Drawing.Size(149, 23);
+            pictureBox_blue.TabIndex = 23;
+            pictureBox_blue.TabStop = false;
+            pictureBox_blue.MouseDown += pictureBox_blue_MouseDown;
+            pictureBox_blue.MouseMove += pictureBox_blue_MouseMove;
             // 
             // groupBox_color
             // 
-            this.groupBox_color.Controls.Add(this.label_red);
-            this.groupBox_color.Controls.Add(this.pictureBox_blue);
-            this.groupBox_color.Controls.Add(this.label_green);
-            this.groupBox_color.Controls.Add(this.pictureBox_green);
-            this.groupBox_color.Controls.Add(this.label_blue);
-            this.groupBox_color.Controls.Add(this.pictureBox_red);
-            this.groupBox_color.Controls.Add(this.numericUpDown_red);
-            this.groupBox_color.Controls.Add(this.numericUpDown_green);
-            this.groupBox_color.Controls.Add(this.numericUpDown_blue);
-            this.groupBox_color.Enabled = false;
-            this.groupBox_color.Location = new System.Drawing.Point(291, 91);
-            this.groupBox_color.Name = "groupBox_color";
-            this.groupBox_color.Size = new System.Drawing.Size(234, 109);
-            this.groupBox_color.TabIndex = 2;
-            this.groupBox_color.TabStop = false;
-            this.groupBox_color.Text = "Color Selector";
+            groupBox_color.Controls.Add(label_html_color);
+            groupBox_color.Controls.Add(textBox_html_color);
+            groupBox_color.Controls.Add(label_red);
+            groupBox_color.Controls.Add(pictureBox_blue);
+            groupBox_color.Controls.Add(label_green);
+            groupBox_color.Controls.Add(pictureBox_green);
+            groupBox_color.Controls.Add(label_blue);
+            groupBox_color.Controls.Add(pictureBox_red);
+            groupBox_color.Controls.Add(numericUpDown_red);
+            groupBox_color.Controls.Add(numericUpDown_green);
+            groupBox_color.Controls.Add(numericUpDown_blue);
+            groupBox_color.Enabled = false;
+            groupBox_color.Location = new System.Drawing.Point(340, 105);
+            groupBox_color.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_color.Name = "groupBox_color";
+            groupBox_color.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_color.Size = new System.Drawing.Size(273, 155);
+            groupBox_color.TabIndex = 2;
+            groupBox_color.TabStop = false;
+            groupBox_color.Text = "Color Selector";
+            // 
+            // label_html_color
+            // 
+            label_html_color.AutoSize = true;
+            label_html_color.Location = new System.Drawing.Point(7, 127);
+            label_html_color.Name = "label_html_color";
+            label_html_color.Size = new System.Drawing.Size(42, 15);
+            label_html_color.TabIndex = 25;
+            label_html_color.Text = "HTML:";
+            // 
+            // textBox_html_color
+            // 
+            textBox_html_color.BorderColor = System.Drawing.Color.Black;
+            textBox_html_color.Location = new System.Drawing.Point(57, 122);
+            textBox_html_color.Multiline = false;
+            textBox_html_color.Name = "textBox_html_color";
+            textBox_html_color.Padding = new System.Windows.Forms.Padding(4, 3, 4, 2);
+            textBox_html_color.ReadOnly = false;
+            textBox_html_color.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_html_color.SelectionStart = 0;
+            textBox_html_color.Size = new System.Drawing.Size(206, 23);
+            textBox_html_color.TabIndex = 24;
+            textBox_html_color.WordWrap = true;
             // 
             // groupBox_shortcuts
             // 
-            this.groupBox_shortcuts.Controls.Add(this.label_sprite);
-            this.groupBox_shortcuts.Controls.Add(this.label_tileset);
-            this.groupBox_shortcuts.Controls.Add(this.comboBox_sprite);
-            this.groupBox_shortcuts.Controls.Add(this.comboBox_tileset);
-            this.groupBox_shortcuts.Location = new System.Drawing.Point(452, 12);
-            this.groupBox_shortcuts.Name = "groupBox_shortcuts";
-            this.groupBox_shortcuts.Size = new System.Drawing.Size(106, 73);
-            this.groupBox_shortcuts.TabIndex = 1;
-            this.groupBox_shortcuts.TabStop = false;
-            this.groupBox_shortcuts.Text = "Shortcuts";
+            groupBox_shortcuts.Controls.Add(label_sprite);
+            groupBox_shortcuts.Controls.Add(label_tileset);
+            groupBox_shortcuts.Controls.Add(comboBox_sprite);
+            groupBox_shortcuts.Controls.Add(comboBox_tileset);
+            groupBox_shortcuts.Location = new System.Drawing.Point(527, 14);
+            groupBox_shortcuts.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_shortcuts.Name = "groupBox_shortcuts";
+            groupBox_shortcuts.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_shortcuts.Size = new System.Drawing.Size(124, 84);
+            groupBox_shortcuts.TabIndex = 1;
+            groupBox_shortcuts.TabStop = false;
+            groupBox_shortcuts.Text = "Shortcuts";
             // 
             // label_sprite
             // 
-            this.label_sprite.AutoSize = true;
-            this.label_sprite.Location = new System.Drawing.Point(6, 49);
-            this.label_sprite.Name = "label_sprite";
-            this.label_sprite.Size = new System.Drawing.Size(37, 13);
-            this.label_sprite.TabIndex = 0;
-            this.label_sprite.Text = "Sprite:";
+            label_sprite.AutoSize = true;
+            label_sprite.Location = new System.Drawing.Point(7, 57);
+            label_sprite.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_sprite.Name = "label_sprite";
+            label_sprite.Size = new System.Drawing.Size(40, 15);
+            label_sprite.TabIndex = 0;
+            label_sprite.Text = "Sprite:";
             // 
             // label_tileset
             // 
-            this.label_tileset.AutoSize = true;
-            this.label_tileset.Location = new System.Drawing.Point(6, 22);
-            this.label_tileset.Name = "label_tileset";
-            this.label_tileset.Size = new System.Drawing.Size(41, 13);
-            this.label_tileset.TabIndex = 0;
-            this.label_tileset.Text = "Tileset:";
+            label_tileset.AutoSize = true;
+            label_tileset.Location = new System.Drawing.Point(7, 25);
+            label_tileset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_tileset.Name = "label_tileset";
+            label_tileset.Size = new System.Drawing.Size(43, 15);
+            label_tileset.TabIndex = 0;
+            label_tileset.Text = "Tileset:";
             // 
             // label_24bitVal
             // 
-            this.label_24bitVal.AutoSize = true;
-            this.label_24bitVal.Location = new System.Drawing.Point(76, 33);
-            this.label_24bitVal.Name = "label_24bitVal";
-            this.label_24bitVal.Size = new System.Drawing.Size(37, 13);
-            this.label_24bitVal.TabIndex = 27;
-            this.label_24bitVal.Text = "0, 0, 0";
+            label_24bitVal.AutoSize = true;
+            label_24bitVal.Location = new System.Drawing.Point(89, 38);
+            label_24bitVal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_24bitVal.Name = "label_24bitVal";
+            label_24bitVal.Size = new System.Drawing.Size(37, 15);
+            label_24bitVal.TabIndex = 27;
+            label_24bitVal.Text = "0, 0, 0";
             // 
             // label_24bit
             // 
-            this.label_24bit.AutoSize = true;
-            this.label_24bit.Location = new System.Drawing.Point(40, 33);
-            this.label_24bit.Name = "label_24bit";
-            this.label_24bit.Size = new System.Drawing.Size(36, 13);
-            this.label_24bit.TabIndex = 26;
-            this.label_24bit.Text = "24-bit:";
+            label_24bit.AutoSize = true;
+            label_24bit.Location = new System.Drawing.Point(47, 38);
+            label_24bit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_24bit.Name = "label_24bit";
+            label_24bit.Size = new System.Drawing.Size(41, 15);
+            label_24bit.TabIndex = 26;
+            label_24bit.Text = "24-bit:";
             // 
             // groupBox_info
             // 
-            this.groupBox_info.Controls.Add(this.pictureBox_chosenColor);
-            this.groupBox_info.Controls.Add(this.label_24bitVal);
-            this.groupBox_info.Controls.Add(this.label_15bit);
-            this.groupBox_info.Controls.Add(this.label_24bit);
-            this.groupBox_info.Controls.Add(this.label_15bitVal);
-            this.groupBox_info.Location = new System.Drawing.Point(291, 206);
-            this.groupBox_info.Name = "groupBox_info";
-            this.groupBox_info.Size = new System.Drawing.Size(154, 55);
-            this.groupBox_info.TabIndex = 0;
-            this.groupBox_info.TabStop = false;
-            this.groupBox_info.Text = "Info";
+            groupBox_info.Controls.Add(pictureBox_chosenColor);
+            groupBox_info.Controls.Add(label_24bitVal);
+            groupBox_info.Controls.Add(label_15bit);
+            groupBox_info.Controls.Add(label_24bit);
+            groupBox_info.Controls.Add(label_15bitVal);
+            groupBox_info.Location = new System.Drawing.Point(341, 266);
+            groupBox_info.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_info.Name = "groupBox_info";
+            groupBox_info.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_info.Size = new System.Drawing.Size(180, 63);
+            groupBox_info.TabIndex = 0;
+            groupBox_info.TabStop = false;
+            groupBox_info.Text = "Info";
             // 
             // statusStrip
             // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusLabel_changes,
-            this.statusStrip_spring,
-            this.statusStrip_import,
-            this.statusStrip_export});
-            this.statusStrip.Location = new System.Drawing.Point(0, 288);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(570, 22);
-            this.statusStrip.TabIndex = 5;
-            this.statusStrip.Text = "statusStrip";
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes, statusStrip_spring, statusStrip_import, statusStrip_export });
+            statusStrip.Location = new System.Drawing.Point(0, 336);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip.Size = new System.Drawing.Size(665, 22);
+            statusStrip.TabIndex = 5;
+            statusStrip.Text = "statusStrip";
             // 
             // statusLabel_changes
             // 
-            this.statusLabel_changes.Name = "statusLabel_changes";
-            this.statusLabel_changes.Size = new System.Drawing.Size(12, 17);
-            this.statusLabel_changes.Text = "-";
+            statusLabel_changes.Name = "statusLabel_changes";
+            statusLabel_changes.Size = new System.Drawing.Size(12, 17);
+            statusLabel_changes.Text = "-";
             // 
             // statusStrip_spring
             // 
-            this.statusStrip_spring.Name = "statusStrip_spring";
-            this.statusStrip_spring.Size = new System.Drawing.Size(433, 17);
-            this.statusStrip_spring.Spring = true;
+            statusStrip_spring.Name = "statusStrip_spring";
+            statusStrip_spring.Size = new System.Drawing.Size(526, 17);
+            statusStrip_spring.Spring = true;
             // 
             // statusStrip_import
             // 
-            this.statusStrip_import.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.statusStrip_import.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusStrip_importRaw,
-            this.statusStrip_importTLP,
-            this.statusStrip_importYY});
-            this.statusStrip_import.Name = "statusStrip_import";
-            this.statusStrip_import.Size = new System.Drawing.Size(56, 20);
-            this.statusStrip_import.Text = "Import";
+            statusStrip_import.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            statusStrip_import.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { statusStrip_importRaw, statusStrip_importTLP, statusStrip_importYY });
+            statusStrip_import.Name = "statusStrip_import";
+            statusStrip_import.Size = new System.Drawing.Size(56, 20);
+            statusStrip_import.Text = "Import";
             // 
             // statusStrip_importRaw
             // 
-            this.statusStrip_importRaw.Name = "statusStrip_importRaw";
-            this.statusStrip_importRaw.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_importRaw.Text = "Raw...";
-            this.statusStrip_importRaw.Click += new System.EventHandler(this.statusStrip_importRaw_Click);
+            statusStrip_importRaw.Name = "statusStrip_importRaw";
+            statusStrip_importRaw.Size = new System.Drawing.Size(153, 22);
+            statusStrip_importRaw.Text = "Raw...";
+            statusStrip_importRaw.Click += statusStrip_importRaw_Click;
             // 
             // statusStrip_importTLP
             // 
-            this.statusStrip_importTLP.Name = "statusStrip_importTLP";
-            this.statusStrip_importTLP.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_importTLP.Text = "Tile Layer Pro...";
-            this.statusStrip_importTLP.Click += new System.EventHandler(this.statusStrip_importTLP_Click);
+            statusStrip_importTLP.Name = "statusStrip_importTLP";
+            statusStrip_importTLP.Size = new System.Drawing.Size(153, 22);
+            statusStrip_importTLP.Text = "Tile Layer Pro...";
+            statusStrip_importTLP.Click += statusStrip_importTLP_Click;
             // 
             // statusStrip_importYY
             // 
-            this.statusStrip_importYY.Name = "statusStrip_importYY";
-            this.statusStrip_importYY.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_importYY.Text = "YY-CHR...";
-            this.statusStrip_importYY.Click += new System.EventHandler(this.statusStrip_importYY_Click);
+            statusStrip_importYY.Name = "statusStrip_importYY";
+            statusStrip_importYY.Size = new System.Drawing.Size(153, 22);
+            statusStrip_importYY.Text = "YY-CHR...";
+            statusStrip_importYY.Click += statusStrip_importYY_Click;
             // 
             // statusStrip_export
             // 
-            this.statusStrip_export.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.statusStrip_export.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusStrip_exportRaw,
-            this.statusStrip_exportTLP,
-            this.statusStrip_exportYY});
-            this.statusStrip_export.Name = "statusStrip_export";
-            this.statusStrip_export.Size = new System.Drawing.Size(54, 20);
-            this.statusStrip_export.Text = "Export";
+            statusStrip_export.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            statusStrip_export.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { statusStrip_exportRaw, statusStrip_exportTLP, statusStrip_exportYY });
+            statusStrip_export.Name = "statusStrip_export";
+            statusStrip_export.Size = new System.Drawing.Size(54, 20);
+            statusStrip_export.Text = "Export";
             // 
             // statusStrip_exportRaw
             // 
-            this.statusStrip_exportRaw.Name = "statusStrip_exportRaw";
-            this.statusStrip_exportRaw.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_exportRaw.Text = "Raw...";
-            this.statusStrip_exportRaw.Click += new System.EventHandler(this.statusStrip_exportRaw_Click);
+            statusStrip_exportRaw.Name = "statusStrip_exportRaw";
+            statusStrip_exportRaw.Size = new System.Drawing.Size(153, 22);
+            statusStrip_exportRaw.Text = "Raw...";
+            statusStrip_exportRaw.Click += statusStrip_exportRaw_Click;
             // 
             // statusStrip_exportTLP
             // 
-            this.statusStrip_exportTLP.Name = "statusStrip_exportTLP";
-            this.statusStrip_exportTLP.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_exportTLP.Text = "Tile Layer Pro...";
-            this.statusStrip_exportTLP.Click += new System.EventHandler(this.statusStrip_exportTLP_Click);
+            statusStrip_exportTLP.Name = "statusStrip_exportTLP";
+            statusStrip_exportTLP.Size = new System.Drawing.Size(153, 22);
+            statusStrip_exportTLP.Text = "Tile Layer Pro...";
+            statusStrip_exportTLP.Click += statusStrip_exportTLP_Click;
             // 
             // statusStrip_exportYY
             // 
-            this.statusStrip_exportYY.Name = "statusStrip_exportYY";
-            this.statusStrip_exportYY.Size = new System.Drawing.Size(153, 22);
-            this.statusStrip_exportYY.Text = "YY-CHR...";
-            this.statusStrip_exportYY.Click += new System.EventHandler(this.statusStrip_exportYY_Click);
+            statusStrip_exportYY.Name = "statusStrip_exportYY";
+            statusStrip_exportYY.Size = new System.Drawing.Size(153, 22);
+            statusStrip_exportYY.Text = "YY-CHR...";
+            statusStrip_exportYY.Click += statusStrip_exportYY_Click;
             // 
             // FormPalette
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(570, 310);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.groupBox_info);
-            this.Controls.Add(this.groupBox_shortcuts);
-            this.Controls.Add(this.groupBox_color);
-            this.Controls.Add(this.button_close);
-            this.Controls.Add(this.button_apply);
-            this.Controls.Add(this.groupBox_offset);
-            this.Controls.Add(this.pictureBox_palette);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "FormPalette";
-            this.Text = "Palette Editor";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_palette)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_chosenColor)).EndInit();
-            this.groupBox_offset.ResumeLayout(false);
-            this.groupBox_offset.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_rows)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_red)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_green)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_blue)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_red)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_green)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_blue)).EndInit();
-            this.groupBox_color.ResumeLayout(false);
-            this.groupBox_color.PerformLayout();
-            this.groupBox_shortcuts.ResumeLayout(false);
-            this.groupBox_shortcuts.PerformLayout();
-            this.groupBox_info.ResumeLayout(false);
-            this.groupBox_info.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(665, 358);
+            Controls.Add(statusStrip);
+            Controls.Add(groupBox_info);
+            Controls.Add(groupBox_shortcuts);
+            Controls.Add(groupBox_color);
+            Controls.Add(button_close);
+            Controls.Add(button_apply);
+            Controls.Add(groupBox_offset);
+            Controls.Add(pictureBox_palette);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "FormPalette";
+            Text = "Palette Editor";
+            ((System.ComponentModel.ISupportInitialize)pictureBox_palette).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_chosenColor).EndInit();
+            groupBox_offset.ResumeLayout(false);
+            groupBox_offset.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_rows).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_red).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_green).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_blue).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_red).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_green).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_blue).EndInit();
+            groupBox_color.ResumeLayout(false);
+            groupBox_color.PerformLayout();
+            groupBox_shortcuts.ResumeLayout(false);
+            groupBox_shortcuts.PerformLayout();
+            groupBox_info.ResumeLayout(false);
+            groupBox_info.PerformLayout();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -605,5 +640,7 @@
         private System.Windows.Forms.ToolStripMenuItem statusStrip_exportRaw;
         private System.Windows.Forms.ToolStripMenuItem statusStrip_exportTLP;
         private System.Windows.Forms.ToolStripMenuItem statusStrip_exportYY;
+        private System.Windows.Forms.Label label_html_color;
+        private Theming.CustomControls.FlatTextBox textBox_html_color;
     }
 }

--- a/mage/Editors/FormPalette.resx
+++ b/mage/Editors/FormPalette.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>54</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAEBAAAAAAGABoAwAAJgAAACAgAAAAABgAqAwAAI4DAAAoAAAAEAAAACAAAAABABgAAAAAAAAD

--- a/mage/Editors/FormSprite.Designer.cs
+++ b/mage/Editors/FormSprite.Designer.cs
@@ -29,710 +29,1064 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormSprite));
-            this.groupBox_vulnerability = new System.Windows.Forms.GroupBox();
-            this.checkBox_powerBombs = new System.Windows.Forms.CheckBox();
-            this.checkBox_beamAndBombs = new System.Windows.Forms.CheckBox();
-            this.checkBox_chargeBeam = new System.Windows.Forms.CheckBox();
-            this.checkBox_superMissiles = new System.Windows.Forms.CheckBox();
-            this.checkBox_missiles = new System.Windows.Forms.CheckBox();
-            this.checkBox_speedScrew = new System.Windows.Forms.CheckBox();
-            this.checkBox_frozen = new System.Windows.Forms.CheckBox();
-            this.groupBox_dropProbability = new System.Windows.Forms.GroupBox();
-            this.label_totalProb = new System.Windows.Forms.Label();
-            this.label_powerBomb = new System.Windows.Forms.Label();
-            this.label_superMissile = new System.Windows.Forms.Label();
-            this.label_missile = new System.Windows.Forms.Label();
-            this.label_largeHealth = new System.Windows.Forms.Label();
-            this.label_smallHealth = new System.Windows.Forms.Label();
-            this.label_noDrop = new System.Windows.Forms.Label();
-            this.textBox_powerBomb = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_superMissile = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_missile = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_largeHealth = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_smallHealth = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_noDrop = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_total = new System.Windows.Forms.Label();
-            this.label_healthX = new System.Windows.Forms.Label();
-            this.textBox_redX = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_missileX = new System.Windows.Forms.Label();
-            this.textBox_missileX = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_redX = new System.Windows.Forms.Label();
-            this.textBox_healthX = new mage.Theming.CustomControls.FlatTextBox();
-            this.groupBox_stats = new System.Windows.Forms.GroupBox();
-            this.label_health = new System.Windows.Forms.Label();
-            this.comboBox_reduction = new mage.Theming.CustomControls.FlatComboBox();
-            this.label_reduction = new System.Windows.Forms.Label();
-            this.textBox_damage = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_health = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_damage = new System.Windows.Forms.Label();
-            this.button_apply = new System.Windows.Forms.Button();
-            this.button_close = new System.Windows.Forms.Button();
-            this.label_sprite = new System.Windows.Forms.Label();
-            this.comboBox_sprite = new mage.Theming.CustomControls.FlatComboBox();
-            this.button_editPalette = new System.Windows.Forms.Button();
-            this.label_type = new System.Windows.Forms.Label();
-            this.comboBox_type = new mage.Theming.CustomControls.FlatComboBox();
-            this.pictureBox_preview = new System.Windows.Forms.PictureBox();
-            this.groupBox_preview = new System.Windows.Forms.GroupBox();
-            this.panel_preview = new System.Windows.Forms.Panel();
-            this.textBox_gfxOffsetVal = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_gfxOffset = new System.Windows.Forms.Label();
-            this.button_editGFX = new System.Windows.Forms.Button();
-            this.label_palOffset = new System.Windows.Forms.Label();
-            this.textBox_palOffsetVal = new mage.Theming.CustomControls.FlatTextBox();
-            this.groupBox_graphics = new System.Windows.Forms.GroupBox();
-            this.label_AI = new System.Windows.Forms.Label();
-            this.textBox_AIoffset = new mage.Theming.CustomControls.FlatTextBox();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
-            this.label_gfxRows = new System.Windows.Forms.Label();
-            this.numericUpDown_gfxRows = new mage.Theming.CustomControls.FlatNumericUpDown();
-            this.groupBox_vulnerability.SuspendLayout();
-            this.groupBox_dropProbability.SuspendLayout();
-            this.groupBox_stats.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_preview)).BeginInit();
-            this.groupBox_preview.SuspendLayout();
-            this.panel_preview.SuspendLayout();
-            this.groupBox_graphics.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_gfxRows)).BeginInit();
-            this.SuspendLayout();
+            groupBox_vulnerability = new System.Windows.Forms.GroupBox();
+            checkBox_powerBombs = new System.Windows.Forms.CheckBox();
+            checkBox_beamAndBombs = new System.Windows.Forms.CheckBox();
+            checkBox_chargeBeam = new System.Windows.Forms.CheckBox();
+            checkBox_superMissiles = new System.Windows.Forms.CheckBox();
+            checkBox_missiles = new System.Windows.Forms.CheckBox();
+            checkBox_speedScrew = new System.Windows.Forms.CheckBox();
+            checkBox_frozen = new System.Windows.Forms.CheckBox();
+            groupBox_dropProbability = new System.Windows.Forms.GroupBox();
+            panel_percentage = new System.Windows.Forms.Panel();
+            textBox_healthXP = new Theming.CustomControls.FlatTextBox();
+            textBox_powerBombP = new Theming.CustomControls.FlatTextBox();
+            textBox_missileXP = new Theming.CustomControls.FlatTextBox();
+            textBox_superMissileP = new Theming.CustomControls.FlatTextBox();
+            textBox_redXP = new Theming.CustomControls.FlatTextBox();
+            textBox_missileP = new Theming.CustomControls.FlatTextBox();
+            textBox_noDropP = new Theming.CustomControls.FlatTextBox();
+            textBox_largeHealthP = new Theming.CustomControls.FlatTextBox();
+            textBox_smallHealthP = new Theming.CustomControls.FlatTextBox();
+            label_totalPercent = new System.Windows.Forms.Label();
+            label_totalProb = new System.Windows.Forms.Label();
+            label_powerBomb = new System.Windows.Forms.Label();
+            label_superMissile = new System.Windows.Forms.Label();
+            label_missile = new System.Windows.Forms.Label();
+            label_largeHealth = new System.Windows.Forms.Label();
+            label_smallHealth = new System.Windows.Forms.Label();
+            label_noDrop = new System.Windows.Forms.Label();
+            textBox_powerBomb = new Theming.CustomControls.FlatTextBox();
+            textBox_superMissile = new Theming.CustomControls.FlatTextBox();
+            textBox_missile = new Theming.CustomControls.FlatTextBox();
+            textBox_largeHealth = new Theming.CustomControls.FlatTextBox();
+            textBox_smallHealth = new Theming.CustomControls.FlatTextBox();
+            textBox_noDrop = new Theming.CustomControls.FlatTextBox();
+            label_total = new System.Windows.Forms.Label();
+            label_healthX = new System.Windows.Forms.Label();
+            textBox_redX = new Theming.CustomControls.FlatTextBox();
+            label_missileX = new System.Windows.Forms.Label();
+            textBox_missileX = new Theming.CustomControls.FlatTextBox();
+            label_redX = new System.Windows.Forms.Label();
+            textBox_healthX = new Theming.CustomControls.FlatTextBox();
+            groupBox_stats = new System.Windows.Forms.GroupBox();
+            label_health = new System.Windows.Forms.Label();
+            comboBox_reduction = new Theming.CustomControls.FlatComboBox();
+            label_reduction = new System.Windows.Forms.Label();
+            textBox_damage = new Theming.CustomControls.FlatTextBox();
+            textBox_health = new Theming.CustomControls.FlatTextBox();
+            label_damage = new System.Windows.Forms.Label();
+            button_apply = new System.Windows.Forms.Button();
+            button_close = new System.Windows.Forms.Button();
+            label_sprite = new System.Windows.Forms.Label();
+            comboBox_sprite = new Theming.CustomControls.FlatComboBox();
+            button_editPalette = new System.Windows.Forms.Button();
+            label_type = new System.Windows.Forms.Label();
+            comboBox_type = new Theming.CustomControls.FlatComboBox();
+            pictureBox_preview = new System.Windows.Forms.PictureBox();
+            groupBox_preview = new System.Windows.Forms.GroupBox();
+            panel_preview = new System.Windows.Forms.Panel();
+            textBox_gfxOffsetVal = new Theming.CustomControls.FlatTextBox();
+            label_gfxOffset = new System.Windows.Forms.Label();
+            button_editGFX = new System.Windows.Forms.Button();
+            label_palOffset = new System.Windows.Forms.Label();
+            textBox_palOffsetVal = new Theming.CustomControls.FlatTextBox();
+            groupBox_graphics = new System.Windows.Forms.GroupBox();
+            numericUpDown_gfxRows = new Theming.CustomControls.FlatNumericUpDown();
+            label_gfxRows = new System.Windows.Forms.Label();
+            label_AI = new System.Windows.Forms.Label();
+            textBox_AIoffset = new Theming.CustomControls.FlatTextBox();
+            statusStrip = new System.Windows.Forms.StatusStrip();
+            statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
+            groupBox_vulnerability.SuspendLayout();
+            groupBox_dropProbability.SuspendLayout();
+            panel_percentage.SuspendLayout();
+            groupBox_stats.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_preview).BeginInit();
+            groupBox_preview.SuspendLayout();
+            panel_preview.SuspendLayout();
+            groupBox_graphics.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_gfxRows).BeginInit();
+            statusStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // groupBox_vulnerability
             // 
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_powerBombs);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_beamAndBombs);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_chargeBeam);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_superMissiles);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_missiles);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_speedScrew);
-            this.groupBox_vulnerability.Controls.Add(this.checkBox_frozen);
-            this.groupBox_vulnerability.Location = new System.Drawing.Point(149, 161);
-            this.groupBox_vulnerability.Name = "groupBox_vulnerability";
-            this.groupBox_vulnerability.Size = new System.Drawing.Size(226, 111);
-            this.groupBox_vulnerability.TabIndex = 5;
-            this.groupBox_vulnerability.TabStop = false;
-            this.groupBox_vulnerability.Text = "Vulnerability";
+            groupBox_vulnerability.Controls.Add(checkBox_powerBombs);
+            groupBox_vulnerability.Controls.Add(checkBox_beamAndBombs);
+            groupBox_vulnerability.Controls.Add(checkBox_chargeBeam);
+            groupBox_vulnerability.Controls.Add(checkBox_superMissiles);
+            groupBox_vulnerability.Controls.Add(checkBox_missiles);
+            groupBox_vulnerability.Controls.Add(checkBox_speedScrew);
+            groupBox_vulnerability.Controls.Add(checkBox_frozen);
+            groupBox_vulnerability.Location = new System.Drawing.Point(174, 186);
+            groupBox_vulnerability.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_vulnerability.Name = "groupBox_vulnerability";
+            groupBox_vulnerability.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_vulnerability.Size = new System.Drawing.Size(264, 128);
+            groupBox_vulnerability.TabIndex = 5;
+            groupBox_vulnerability.TabStop = false;
+            groupBox_vulnerability.Text = "Vulnerability";
             // 
             // checkBox_powerBombs
             // 
-            this.checkBox_powerBombs.AutoSize = true;
-            this.checkBox_powerBombs.Location = new System.Drawing.Point(127, 19);
-            this.checkBox_powerBombs.Name = "checkBox_powerBombs";
-            this.checkBox_powerBombs.Size = new System.Drawing.Size(90, 17);
-            this.checkBox_powerBombs.TabIndex = 4;
-            this.checkBox_powerBombs.Text = "Power bombs";
-            this.checkBox_powerBombs.UseVisualStyleBackColor = true;
-            this.checkBox_powerBombs.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_powerBombs.AutoSize = true;
+            checkBox_powerBombs.Location = new System.Drawing.Point(148, 22);
+            checkBox_powerBombs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_powerBombs.Name = "checkBox_powerBombs";
+            checkBox_powerBombs.Size = new System.Drawing.Size(99, 19);
+            checkBox_powerBombs.TabIndex = 4;
+            checkBox_powerBombs.Text = "Power bombs";
+            checkBox_powerBombs.UseVisualStyleBackColor = true;
+            checkBox_powerBombs.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_beamAndBombs
             // 
-            this.checkBox_beamAndBombs.AutoSize = true;
-            this.checkBox_beamAndBombs.Location = new System.Drawing.Point(9, 19);
-            this.checkBox_beamAndBombs.Name = "checkBox_beamAndBombs";
-            this.checkBox_beamAndBombs.Size = new System.Drawing.Size(108, 17);
-            this.checkBox_beamAndBombs.TabIndex = 0;
-            this.checkBox_beamAndBombs.Text = "Beam and bombs";
-            this.checkBox_beamAndBombs.UseVisualStyleBackColor = true;
-            this.checkBox_beamAndBombs.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_beamAndBombs.AutoSize = true;
+            checkBox_beamAndBombs.Location = new System.Drawing.Point(10, 22);
+            checkBox_beamAndBombs.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_beamAndBombs.Name = "checkBox_beamAndBombs";
+            checkBox_beamAndBombs.Size = new System.Drawing.Size(119, 19);
+            checkBox_beamAndBombs.TabIndex = 0;
+            checkBox_beamAndBombs.Text = "Beam and bombs";
+            checkBox_beamAndBombs.UseVisualStyleBackColor = true;
+            checkBox_beamAndBombs.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_chargeBeam
             // 
-            this.checkBox_chargeBeam.AutoSize = true;
-            this.checkBox_chargeBeam.Location = new System.Drawing.Point(9, 42);
-            this.checkBox_chargeBeam.Name = "checkBox_chargeBeam";
-            this.checkBox_chargeBeam.Size = new System.Drawing.Size(89, 17);
-            this.checkBox_chargeBeam.TabIndex = 1;
-            this.checkBox_chargeBeam.Text = "Charge beam";
-            this.checkBox_chargeBeam.UseVisualStyleBackColor = true;
-            this.checkBox_chargeBeam.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_chargeBeam.AutoSize = true;
+            checkBox_chargeBeam.Location = new System.Drawing.Point(10, 48);
+            checkBox_chargeBeam.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_chargeBeam.Name = "checkBox_chargeBeam";
+            checkBox_chargeBeam.Size = new System.Drawing.Size(97, 19);
+            checkBox_chargeBeam.TabIndex = 1;
+            checkBox_chargeBeam.Text = "Charge beam";
+            checkBox_chargeBeam.UseVisualStyleBackColor = true;
+            checkBox_chargeBeam.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_superMissiles
             // 
-            this.checkBox_superMissiles.AutoSize = true;
-            this.checkBox_superMissiles.Location = new System.Drawing.Point(9, 88);
-            this.checkBox_superMissiles.Name = "checkBox_superMissiles";
-            this.checkBox_superMissiles.Size = new System.Drawing.Size(92, 17);
-            this.checkBox_superMissiles.TabIndex = 3;
-            this.checkBox_superMissiles.Text = "Super missiles";
-            this.checkBox_superMissiles.UseVisualStyleBackColor = true;
-            this.checkBox_superMissiles.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_superMissiles.AutoSize = true;
+            checkBox_superMissiles.Location = new System.Drawing.Point(10, 102);
+            checkBox_superMissiles.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_superMissiles.Name = "checkBox_superMissiles";
+            checkBox_superMissiles.Size = new System.Drawing.Size(100, 19);
+            checkBox_superMissiles.TabIndex = 3;
+            checkBox_superMissiles.Text = "Super missiles";
+            checkBox_superMissiles.UseVisualStyleBackColor = true;
+            checkBox_superMissiles.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_missiles
             // 
-            this.checkBox_missiles.AutoSize = true;
-            this.checkBox_missiles.Location = new System.Drawing.Point(9, 65);
-            this.checkBox_missiles.Name = "checkBox_missiles";
-            this.checkBox_missiles.Size = new System.Drawing.Size(62, 17);
-            this.checkBox_missiles.TabIndex = 2;
-            this.checkBox_missiles.Text = "Missiles";
-            this.checkBox_missiles.UseVisualStyleBackColor = true;
-            this.checkBox_missiles.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_missiles.AutoSize = true;
+            checkBox_missiles.Location = new System.Drawing.Point(10, 75);
+            checkBox_missiles.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_missiles.Name = "checkBox_missiles";
+            checkBox_missiles.Size = new System.Drawing.Size(67, 19);
+            checkBox_missiles.TabIndex = 2;
+            checkBox_missiles.Text = "Missiles";
+            checkBox_missiles.UseVisualStyleBackColor = true;
+            checkBox_missiles.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_speedScrew
             // 
-            this.checkBox_speedScrew.AutoSize = true;
-            this.checkBox_speedScrew.Location = new System.Drawing.Point(127, 47);
-            this.checkBox_speedScrew.Name = "checkBox_speedScrew";
-            this.checkBox_speedScrew.Size = new System.Drawing.Size(95, 30);
-            this.checkBox_speedScrew.TabIndex = 5;
-            this.checkBox_speedScrew.Text = "Speed booster\r\nScrew attack";
-            this.checkBox_speedScrew.UseVisualStyleBackColor = true;
-            this.checkBox_speedScrew.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_speedScrew.AutoSize = true;
+            checkBox_speedScrew.Location = new System.Drawing.Point(148, 54);
+            checkBox_speedScrew.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_speedScrew.Name = "checkBox_speedScrew";
+            checkBox_speedScrew.Size = new System.Drawing.Size(101, 34);
+            checkBox_speedScrew.TabIndex = 5;
+            checkBox_speedScrew.Text = "Speed booster\r\nScrew attack";
+            checkBox_speedScrew.UseVisualStyleBackColor = true;
+            checkBox_speedScrew.CheckedChanged += SpriteValueChanged;
             // 
             // checkBox_frozen
             // 
-            this.checkBox_frozen.AutoSize = true;
-            this.checkBox_frozen.Location = new System.Drawing.Point(127, 88);
-            this.checkBox_frozen.Name = "checkBox_frozen";
-            this.checkBox_frozen.Size = new System.Drawing.Size(92, 17);
-            this.checkBox_frozen.TabIndex = 6;
-            this.checkBox_frozen.Text = "Can be frozen";
-            this.checkBox_frozen.UseVisualStyleBackColor = true;
-            this.checkBox_frozen.CheckedChanged += new System.EventHandler(this.SpriteValueChanged);
+            checkBox_frozen.AutoSize = true;
+            checkBox_frozen.Location = new System.Drawing.Point(148, 102);
+            checkBox_frozen.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_frozen.Name = "checkBox_frozen";
+            checkBox_frozen.Size = new System.Drawing.Size(99, 19);
+            checkBox_frozen.TabIndex = 6;
+            checkBox_frozen.Text = "Can be frozen";
+            checkBox_frozen.UseVisualStyleBackColor = true;
+            checkBox_frozen.CheckedChanged += SpriteValueChanged;
             // 
             // groupBox_dropProbability
             // 
-            this.groupBox_dropProbability.Controls.Add(this.label_totalProb);
-            this.groupBox_dropProbability.Controls.Add(this.label_powerBomb);
-            this.groupBox_dropProbability.Controls.Add(this.label_superMissile);
-            this.groupBox_dropProbability.Controls.Add(this.label_missile);
-            this.groupBox_dropProbability.Controls.Add(this.label_largeHealth);
-            this.groupBox_dropProbability.Controls.Add(this.label_smallHealth);
-            this.groupBox_dropProbability.Controls.Add(this.label_noDrop);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_powerBomb);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_superMissile);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_missile);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_largeHealth);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_smallHealth);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_noDrop);
-            this.groupBox_dropProbability.Controls.Add(this.label_total);
-            this.groupBox_dropProbability.Controls.Add(this.label_healthX);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_redX);
-            this.groupBox_dropProbability.Controls.Add(this.label_missileX);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_missileX);
-            this.groupBox_dropProbability.Controls.Add(this.label_redX);
-            this.groupBox_dropProbability.Controls.Add(this.textBox_healthX);
-            this.groupBox_dropProbability.Location = new System.Drawing.Point(381, 40);
-            this.groupBox_dropProbability.Name = "groupBox_dropProbability";
-            this.groupBox_dropProbability.Size = new System.Drawing.Size(135, 267);
-            this.groupBox_dropProbability.TabIndex = 3;
-            this.groupBox_dropProbability.TabStop = false;
-            this.groupBox_dropProbability.Text = "Drop Probability";
+            groupBox_dropProbability.Controls.Add(panel_percentage);
+            groupBox_dropProbability.Controls.Add(label_totalPercent);
+            groupBox_dropProbability.Controls.Add(label_totalProb);
+            groupBox_dropProbability.Controls.Add(label_powerBomb);
+            groupBox_dropProbability.Controls.Add(label_superMissile);
+            groupBox_dropProbability.Controls.Add(label_missile);
+            groupBox_dropProbability.Controls.Add(label_largeHealth);
+            groupBox_dropProbability.Controls.Add(label_smallHealth);
+            groupBox_dropProbability.Controls.Add(label_noDrop);
+            groupBox_dropProbability.Controls.Add(textBox_powerBomb);
+            groupBox_dropProbability.Controls.Add(textBox_superMissile);
+            groupBox_dropProbability.Controls.Add(textBox_missile);
+            groupBox_dropProbability.Controls.Add(textBox_largeHealth);
+            groupBox_dropProbability.Controls.Add(textBox_smallHealth);
+            groupBox_dropProbability.Controls.Add(textBox_noDrop);
+            groupBox_dropProbability.Controls.Add(label_total);
+            groupBox_dropProbability.Controls.Add(label_healthX);
+            groupBox_dropProbability.Controls.Add(textBox_redX);
+            groupBox_dropProbability.Controls.Add(label_missileX);
+            groupBox_dropProbability.Controls.Add(textBox_missileX);
+            groupBox_dropProbability.Controls.Add(label_redX);
+            groupBox_dropProbability.Controls.Add(textBox_healthX);
+            groupBox_dropProbability.Location = new System.Drawing.Point(444, 46);
+            groupBox_dropProbability.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_dropProbability.Name = "groupBox_dropProbability";
+            groupBox_dropProbability.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_dropProbability.Size = new System.Drawing.Size(208, 308);
+            groupBox_dropProbability.TabIndex = 3;
+            groupBox_dropProbability.TabStop = false;
+            groupBox_dropProbability.Text = "Drop Probability";
+            // 
+            // panel_percentage
+            // 
+            panel_percentage.Controls.Add(textBox_healthXP);
+            panel_percentage.Controls.Add(textBox_powerBombP);
+            panel_percentage.Controls.Add(textBox_missileXP);
+            panel_percentage.Controls.Add(textBox_superMissileP);
+            panel_percentage.Controls.Add(textBox_redXP);
+            panel_percentage.Controls.Add(textBox_missileP);
+            panel_percentage.Controls.Add(textBox_noDropP);
+            panel_percentage.Controls.Add(textBox_largeHealthP);
+            panel_percentage.Controls.Add(textBox_smallHealthP);
+            panel_percentage.Location = new System.Drawing.Point(152, 45);
+            panel_percentage.Name = "panel_percentage";
+            panel_percentage.Size = new System.Drawing.Size(52, 257);
+            panel_percentage.TabIndex = 20;
+            // 
+            // textBox_healthXP
+            // 
+            textBox_healthXP.BorderColor = System.Drawing.Color.Black;
+            textBox_healthXP.Location = new System.Drawing.Point(0, 0);
+            textBox_healthXP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_healthXP.Multiline = false;
+            textBox_healthXP.Name = "textBox_healthXP";
+            textBox_healthXP.OnTextChanged = null;
+            textBox_healthXP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_healthXP.ReadOnly = false;
+            textBox_healthXP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_healthXP.SelectionStart = 0;
+            textBox_healthXP.Size = new System.Drawing.Size(47, 23);
+            textBox_healthXP.TabIndex = 10;
+            textBox_healthXP.Tag = "textBox_healthX";
+            textBox_healthXP.WordWrap = true;
+            // 
+            // textBox_powerBombP
+            // 
+            textBox_powerBombP.BorderColor = System.Drawing.Color.Black;
+            textBox_powerBombP.Location = new System.Drawing.Point(0, 231);
+            textBox_powerBombP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_powerBombP.Multiline = false;
+            textBox_powerBombP.Name = "textBox_powerBombP";
+            textBox_powerBombP.OnTextChanged = null;
+            textBox_powerBombP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_powerBombP.ReadOnly = false;
+            textBox_powerBombP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_powerBombP.SelectionStart = 0;
+            textBox_powerBombP.Size = new System.Drawing.Size(47, 23);
+            textBox_powerBombP.TabIndex = 18;
+            textBox_powerBombP.Tag = "textBox_powerBomb";
+            textBox_powerBombP.WordWrap = true;
+            // 
+            // textBox_missileXP
+            // 
+            textBox_missileXP.BorderColor = System.Drawing.Color.Black;
+            textBox_missileXP.Location = new System.Drawing.Point(0, 29);
+            textBox_missileXP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_missileXP.Multiline = false;
+            textBox_missileXP.Name = "textBox_missileXP";
+            textBox_missileXP.OnTextChanged = null;
+            textBox_missileXP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_missileXP.ReadOnly = false;
+            textBox_missileXP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_missileXP.SelectionStart = 0;
+            textBox_missileXP.Size = new System.Drawing.Size(47, 23);
+            textBox_missileXP.TabIndex = 11;
+            textBox_missileXP.Tag = "textBox_missileX";
+            textBox_missileXP.WordWrap = true;
+            // 
+            // textBox_superMissileP
+            // 
+            textBox_superMissileP.BorderColor = System.Drawing.Color.Black;
+            textBox_superMissileP.Location = new System.Drawing.Point(0, 202);
+            textBox_superMissileP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_superMissileP.Multiline = false;
+            textBox_superMissileP.Name = "textBox_superMissileP";
+            textBox_superMissileP.OnTextChanged = null;
+            textBox_superMissileP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_superMissileP.ReadOnly = false;
+            textBox_superMissileP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_superMissileP.SelectionStart = 0;
+            textBox_superMissileP.Size = new System.Drawing.Size(47, 23);
+            textBox_superMissileP.TabIndex = 17;
+            textBox_superMissileP.Tag = "textBox_superMissile";
+            textBox_superMissileP.WordWrap = true;
+            // 
+            // textBox_redXP
+            // 
+            textBox_redXP.BorderColor = System.Drawing.Color.Black;
+            textBox_redXP.Location = new System.Drawing.Point(0, 58);
+            textBox_redXP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_redXP.Multiline = false;
+            textBox_redXP.Name = "textBox_redXP";
+            textBox_redXP.OnTextChanged = null;
+            textBox_redXP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_redXP.ReadOnly = false;
+            textBox_redXP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_redXP.SelectionStart = 0;
+            textBox_redXP.Size = new System.Drawing.Size(47, 23);
+            textBox_redXP.TabIndex = 12;
+            textBox_redXP.Tag = "textBox_redX";
+            textBox_redXP.WordWrap = true;
+            // 
+            // textBox_missileP
+            // 
+            textBox_missileP.BorderColor = System.Drawing.Color.Black;
+            textBox_missileP.Location = new System.Drawing.Point(0, 173);
+            textBox_missileP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_missileP.Multiline = false;
+            textBox_missileP.Name = "textBox_missileP";
+            textBox_missileP.OnTextChanged = null;
+            textBox_missileP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_missileP.ReadOnly = false;
+            textBox_missileP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_missileP.SelectionStart = 0;
+            textBox_missileP.Size = new System.Drawing.Size(47, 23);
+            textBox_missileP.TabIndex = 16;
+            textBox_missileP.Tag = "textBox_missile";
+            textBox_missileP.WordWrap = true;
+            // 
+            // textBox_noDropP
+            // 
+            textBox_noDropP.BorderColor = System.Drawing.Color.Black;
+            textBox_noDropP.Location = new System.Drawing.Point(0, 87);
+            textBox_noDropP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_noDropP.Multiline = false;
+            textBox_noDropP.Name = "textBox_noDropP";
+            textBox_noDropP.OnTextChanged = null;
+            textBox_noDropP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_noDropP.ReadOnly = false;
+            textBox_noDropP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_noDropP.SelectionStart = 0;
+            textBox_noDropP.Size = new System.Drawing.Size(47, 23);
+            textBox_noDropP.TabIndex = 13;
+            textBox_noDropP.Tag = "textBox_noDrop";
+            textBox_noDropP.WordWrap = true;
+            // 
+            // textBox_largeHealthP
+            // 
+            textBox_largeHealthP.BorderColor = System.Drawing.Color.Black;
+            textBox_largeHealthP.Location = new System.Drawing.Point(0, 144);
+            textBox_largeHealthP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_largeHealthP.Multiline = false;
+            textBox_largeHealthP.Name = "textBox_largeHealthP";
+            textBox_largeHealthP.OnTextChanged = null;
+            textBox_largeHealthP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_largeHealthP.ReadOnly = false;
+            textBox_largeHealthP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_largeHealthP.SelectionStart = 0;
+            textBox_largeHealthP.Size = new System.Drawing.Size(47, 23);
+            textBox_largeHealthP.TabIndex = 15;
+            textBox_largeHealthP.Tag = "textBox_largeHealth";
+            textBox_largeHealthP.WordWrap = true;
+            // 
+            // textBox_smallHealthP
+            // 
+            textBox_smallHealthP.BorderColor = System.Drawing.Color.Black;
+            textBox_smallHealthP.Location = new System.Drawing.Point(0, 116);
+            textBox_smallHealthP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_smallHealthP.Multiline = false;
+            textBox_smallHealthP.Name = "textBox_smallHealthP";
+            textBox_smallHealthP.OnTextChanged = null;
+            textBox_smallHealthP.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_smallHealthP.ReadOnly = false;
+            textBox_smallHealthP.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_smallHealthP.SelectionStart = 0;
+            textBox_smallHealthP.Size = new System.Drawing.Size(47, 23);
+            textBox_smallHealthP.TabIndex = 14;
+            textBox_smallHealthP.Tag = "textBox_smallHealth";
+            textBox_smallHealthP.WordWrap = true;
+            // 
+            // label_totalPercent
+            // 
+            label_totalPercent.Location = new System.Drawing.Point(152, 20);
+            label_totalPercent.Name = "label_totalPercent";
+            label_totalPercent.Size = new System.Drawing.Size(48, 16);
+            label_totalPercent.TabIndex = 19;
+            label_totalPercent.Text = "100%";
+            label_totalPercent.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label_totalProb
             // 
-            this.label_totalProb.AutoSize = true;
-            this.label_totalProb.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_totalProb.Location = new System.Drawing.Point(46, 19);
-            this.label_totalProb.Name = "label_totalProb";
-            this.label_totalProb.Size = new System.Drawing.Size(25, 13);
-            this.label_totalProb.TabIndex = 9;
-            this.label_totalProb.Text = "400";
+            label_totalProb.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            label_totalProb.Location = new System.Drawing.Point(49, 21);
+            label_totalProb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_totalProb.Name = "label_totalProb";
+            label_totalProb.Size = new System.Drawing.Size(96, 15);
+            label_totalProb.TabIndex = 9;
+            label_totalProb.Text = "400";
+            label_totalProb.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label_powerBomb
             // 
-            this.label_powerBomb.AutoSize = true;
-            this.label_powerBomb.Location = new System.Drawing.Point(7, 242);
-            this.label_powerBomb.Name = "label_powerBomb";
-            this.label_powerBomb.Size = new System.Drawing.Size(69, 13);
-            this.label_powerBomb.TabIndex = 0;
-            this.label_powerBomb.Text = "Power bomb:";
+            label_powerBomb.AutoSize = true;
+            label_powerBomb.Location = new System.Drawing.Point(8, 279);
+            label_powerBomb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_powerBomb.Name = "label_powerBomb";
+            label_powerBomb.Size = new System.Drawing.Size(78, 15);
+            label_powerBomb.TabIndex = 0;
+            label_powerBomb.Text = "Power bomb:";
             // 
             // label_superMissile
             // 
-            this.label_superMissile.AutoSize = true;
-            this.label_superMissile.Location = new System.Drawing.Point(7, 217);
-            this.label_superMissile.Name = "label_superMissile";
-            this.label_superMissile.Size = new System.Drawing.Size(71, 13);
-            this.label_superMissile.TabIndex = 0;
-            this.label_superMissile.Text = "Super missile:";
+            label_superMissile.AutoSize = true;
+            label_superMissile.Location = new System.Drawing.Point(8, 250);
+            label_superMissile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_superMissile.Name = "label_superMissile";
+            label_superMissile.Size = new System.Drawing.Size(79, 15);
+            label_superMissile.TabIndex = 0;
+            label_superMissile.Text = "Super missile:";
             // 
             // label_missile
             // 
-            this.label_missile.AutoSize = true;
-            this.label_missile.Location = new System.Drawing.Point(7, 192);
-            this.label_missile.Name = "label_missile";
-            this.label_missile.Size = new System.Drawing.Size(41, 13);
-            this.label_missile.TabIndex = 0;
-            this.label_missile.Text = "Missile:";
+            label_missile.AutoSize = true;
+            label_missile.Location = new System.Drawing.Point(8, 222);
+            label_missile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_missile.Name = "label_missile";
+            label_missile.Size = new System.Drawing.Size(46, 15);
+            label_missile.TabIndex = 0;
+            label_missile.Text = "Missile:";
             // 
             // label_largeHealth
             // 
-            this.label_largeHealth.AutoSize = true;
-            this.label_largeHealth.Location = new System.Drawing.Point(7, 167);
-            this.label_largeHealth.Name = "label_largeHealth";
-            this.label_largeHealth.Size = new System.Drawing.Size(69, 13);
-            this.label_largeHealth.TabIndex = 0;
-            this.label_largeHealth.Text = "Large health:";
+            label_largeHealth.AutoSize = true;
+            label_largeHealth.Location = new System.Drawing.Point(8, 193);
+            label_largeHealth.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_largeHealth.Name = "label_largeHealth";
+            label_largeHealth.Size = new System.Drawing.Size(75, 15);
+            label_largeHealth.TabIndex = 0;
+            label_largeHealth.Text = "Large health:";
             // 
             // label_smallHealth
             // 
-            this.label_smallHealth.AutoSize = true;
-            this.label_smallHealth.Location = new System.Drawing.Point(7, 142);
-            this.label_smallHealth.Name = "label_smallHealth";
-            this.label_smallHealth.Size = new System.Drawing.Size(67, 13);
-            this.label_smallHealth.TabIndex = 0;
-            this.label_smallHealth.Text = "Small health:";
+            label_smallHealth.AutoSize = true;
+            label_smallHealth.Location = new System.Drawing.Point(8, 164);
+            label_smallHealth.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_smallHealth.Name = "label_smallHealth";
+            label_smallHealth.Size = new System.Drawing.Size(75, 15);
+            label_smallHealth.TabIndex = 0;
+            label_smallHealth.Text = "Small health:";
             // 
             // label_noDrop
             // 
-            this.label_noDrop.AutoSize = true;
-            this.label_noDrop.Location = new System.Drawing.Point(7, 117);
-            this.label_noDrop.Name = "label_noDrop";
-            this.label_noDrop.Size = new System.Drawing.Size(48, 13);
-            this.label_noDrop.TabIndex = 0;
-            this.label_noDrop.Text = "No drop:";
+            label_noDrop.AutoSize = true;
+            label_noDrop.Location = new System.Drawing.Point(8, 135);
+            label_noDrop.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_noDrop.Name = "label_noDrop";
+            label_noDrop.Size = new System.Drawing.Size(54, 15);
+            label_noDrop.TabIndex = 0;
+            label_noDrop.Text = "No drop:";
             // 
             // textBox_powerBomb
             // 
-            this.textBox_powerBomb.Location = new System.Drawing.Point(84, 239);
-            this.textBox_powerBomb.Name = "textBox_powerBomb";
-            this.textBox_powerBomb.Size = new System.Drawing.Size(40, 20);
-            this.textBox_powerBomb.TabIndex = 8;
-            this.textBox_powerBomb.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_powerBomb.BorderColor = System.Drawing.Color.Black;
+            textBox_powerBomb.Location = new System.Drawing.Point(98, 276);
+            textBox_powerBomb.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_powerBomb.Multiline = false;
+            textBox_powerBomb.Name = "textBox_powerBomb";
+            textBox_powerBomb.OnTextChanged = null;
+            textBox_powerBomb.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_powerBomb.ReadOnly = false;
+            textBox_powerBomb.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_powerBomb.SelectionStart = 0;
+            textBox_powerBomb.Size = new System.Drawing.Size(47, 23);
+            textBox_powerBomb.TabIndex = 8;
+            textBox_powerBomb.Tag = "textBox_powerBombP";
+            textBox_powerBomb.WordWrap = true;
+            textBox_powerBomb.TextChanged += textBox_dropProb_TextChanged;
             // 
             // textBox_superMissile
             // 
-            this.textBox_superMissile.Location = new System.Drawing.Point(84, 214);
-            this.textBox_superMissile.Name = "textBox_superMissile";
-            this.textBox_superMissile.Size = new System.Drawing.Size(40, 20);
-            this.textBox_superMissile.TabIndex = 7;
-            this.textBox_superMissile.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_superMissile.BorderColor = System.Drawing.Color.Black;
+            textBox_superMissile.Location = new System.Drawing.Point(98, 247);
+            textBox_superMissile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_superMissile.Multiline = false;
+            textBox_superMissile.Name = "textBox_superMissile";
+            textBox_superMissile.OnTextChanged = null;
+            textBox_superMissile.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_superMissile.ReadOnly = false;
+            textBox_superMissile.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_superMissile.SelectionStart = 0;
+            textBox_superMissile.Size = new System.Drawing.Size(47, 23);
+            textBox_superMissile.TabIndex = 7;
+            textBox_superMissile.Tag = "textBox_superMissileP";
+            textBox_superMissile.WordWrap = true;
+            textBox_superMissile.TextChanged += textBox_dropProb_TextChanged;
             // 
             // textBox_missile
             // 
-            this.textBox_missile.Location = new System.Drawing.Point(84, 189);
-            this.textBox_missile.Name = "textBox_missile";
-            this.textBox_missile.Size = new System.Drawing.Size(40, 20);
-            this.textBox_missile.TabIndex = 6;
-            this.textBox_missile.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_missile.BorderColor = System.Drawing.Color.Black;
+            textBox_missile.Location = new System.Drawing.Point(98, 218);
+            textBox_missile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_missile.Multiline = false;
+            textBox_missile.Name = "textBox_missile";
+            textBox_missile.OnTextChanged = null;
+            textBox_missile.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_missile.ReadOnly = false;
+            textBox_missile.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_missile.SelectionStart = 0;
+            textBox_missile.Size = new System.Drawing.Size(47, 23);
+            textBox_missile.TabIndex = 6;
+            textBox_missile.Tag = "textBox_missileP";
+            textBox_missile.WordWrap = true;
+            textBox_missile.TextChanged += textBox_dropProb_TextChanged;
             // 
             // textBox_largeHealth
             // 
-            this.textBox_largeHealth.Location = new System.Drawing.Point(84, 164);
-            this.textBox_largeHealth.Name = "textBox_largeHealth";
-            this.textBox_largeHealth.Size = new System.Drawing.Size(40, 20);
-            this.textBox_largeHealth.TabIndex = 5;
-            this.textBox_largeHealth.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_largeHealth.BorderColor = System.Drawing.Color.Black;
+            textBox_largeHealth.Location = new System.Drawing.Point(98, 189);
+            textBox_largeHealth.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_largeHealth.Multiline = false;
+            textBox_largeHealth.Name = "textBox_largeHealth";
+            textBox_largeHealth.OnTextChanged = null;
+            textBox_largeHealth.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_largeHealth.ReadOnly = false;
+            textBox_largeHealth.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_largeHealth.SelectionStart = 0;
+            textBox_largeHealth.Size = new System.Drawing.Size(47, 23);
+            textBox_largeHealth.TabIndex = 5;
+            textBox_largeHealth.Tag = "textBox_largeHealthP";
+            textBox_largeHealth.WordWrap = true;
+            textBox_largeHealth.TextChanged += textBox_dropProb_TextChanged;
             // 
             // textBox_smallHealth
             // 
-            this.textBox_smallHealth.Location = new System.Drawing.Point(84, 139);
-            this.textBox_smallHealth.Name = "textBox_smallHealth";
-            this.textBox_smallHealth.Size = new System.Drawing.Size(40, 20);
-            this.textBox_smallHealth.TabIndex = 4;
-            this.textBox_smallHealth.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_smallHealth.BorderColor = System.Drawing.Color.Black;
+            textBox_smallHealth.Location = new System.Drawing.Point(98, 160);
+            textBox_smallHealth.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_smallHealth.Multiline = false;
+            textBox_smallHealth.Name = "textBox_smallHealth";
+            textBox_smallHealth.OnTextChanged = null;
+            textBox_smallHealth.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_smallHealth.ReadOnly = false;
+            textBox_smallHealth.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_smallHealth.SelectionStart = 0;
+            textBox_smallHealth.Size = new System.Drawing.Size(47, 23);
+            textBox_smallHealth.TabIndex = 4;
+            textBox_smallHealth.Tag = "textBox_smallHealthP";
+            textBox_smallHealth.WordWrap = true;
+            textBox_smallHealth.TextChanged += textBox_dropProb_TextChanged;
             // 
             // textBox_noDrop
             // 
-            this.textBox_noDrop.Location = new System.Drawing.Point(84, 114);
-            this.textBox_noDrop.Name = "textBox_noDrop";
-            this.textBox_noDrop.Size = new System.Drawing.Size(40, 20);
-            this.textBox_noDrop.TabIndex = 3;
-            this.textBox_noDrop.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_noDrop.BorderColor = System.Drawing.Color.Black;
+            textBox_noDrop.Location = new System.Drawing.Point(98, 132);
+            textBox_noDrop.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_noDrop.Multiline = false;
+            textBox_noDrop.Name = "textBox_noDrop";
+            textBox_noDrop.OnTextChanged = null;
+            textBox_noDrop.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_noDrop.ReadOnly = false;
+            textBox_noDrop.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_noDrop.SelectionStart = 0;
+            textBox_noDrop.Size = new System.Drawing.Size(47, 23);
+            textBox_noDrop.TabIndex = 3;
+            textBox_noDrop.Tag = "textBox_noDropP";
+            textBox_noDrop.WordWrap = true;
+            textBox_noDrop.TextChanged += textBox_dropProb_TextChanged;
             // 
             // label_total
             // 
-            this.label_total.AutoSize = true;
-            this.label_total.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_total.Location = new System.Drawing.Point(6, 19);
-            this.label_total.Name = "label_total";
-            this.label_total.Size = new System.Drawing.Size(34, 13);
-            this.label_total.TabIndex = 0;
-            this.label_total.Text = "Total:";
+            label_total.AutoSize = true;
+            label_total.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            label_total.Location = new System.Drawing.Point(7, 22);
+            label_total.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_total.Name = "label_total";
+            label_total.Size = new System.Drawing.Size(34, 13);
+            label_total.TabIndex = 0;
+            label_total.Text = "Total:";
             // 
             // label_healthX
             // 
-            this.label_healthX.AutoSize = true;
-            this.label_healthX.Location = new System.Drawing.Point(6, 42);
-            this.label_healthX.Name = "label_healthX";
-            this.label_healthX.Size = new System.Drawing.Size(51, 13);
-            this.label_healthX.TabIndex = 0;
-            this.label_healthX.Text = "Health X:";
+            label_healthX.AutoSize = true;
+            label_healthX.Location = new System.Drawing.Point(7, 48);
+            label_healthX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_healthX.Name = "label_healthX";
+            label_healthX.Size = new System.Drawing.Size(55, 15);
+            label_healthX.TabIndex = 0;
+            label_healthX.Text = "Health X:";
             // 
             // textBox_redX
             // 
-            this.textBox_redX.Location = new System.Drawing.Point(84, 89);
-            this.textBox_redX.Name = "textBox_redX";
-            this.textBox_redX.Size = new System.Drawing.Size(40, 20);
-            this.textBox_redX.TabIndex = 2;
-            this.textBox_redX.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_redX.BorderColor = System.Drawing.Color.Black;
+            textBox_redX.Location = new System.Drawing.Point(98, 103);
+            textBox_redX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_redX.Multiline = false;
+            textBox_redX.Name = "textBox_redX";
+            textBox_redX.OnTextChanged = null;
+            textBox_redX.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_redX.ReadOnly = false;
+            textBox_redX.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_redX.SelectionStart = 0;
+            textBox_redX.Size = new System.Drawing.Size(47, 23);
+            textBox_redX.TabIndex = 2;
+            textBox_redX.Tag = "textBox_redXP";
+            textBox_redX.WordWrap = true;
+            textBox_redX.TextChanged += textBox_dropProb_TextChanged;
             // 
             // label_missileX
             // 
-            this.label_missileX.AutoSize = true;
-            this.label_missileX.Location = new System.Drawing.Point(6, 67);
-            this.label_missileX.Name = "label_missileX";
-            this.label_missileX.Size = new System.Drawing.Size(51, 13);
-            this.label_missileX.TabIndex = 0;
-            this.label_missileX.Text = "Missile X:";
+            label_missileX.AutoSize = true;
+            label_missileX.Location = new System.Drawing.Point(7, 77);
+            label_missileX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_missileX.Name = "label_missileX";
+            label_missileX.Size = new System.Drawing.Size(56, 15);
+            label_missileX.TabIndex = 0;
+            label_missileX.Text = "Missile X:";
             // 
             // textBox_missileX
             // 
-            this.textBox_missileX.Location = new System.Drawing.Point(84, 64);
-            this.textBox_missileX.Name = "textBox_missileX";
-            this.textBox_missileX.Size = new System.Drawing.Size(40, 20);
-            this.textBox_missileX.TabIndex = 1;
-            this.textBox_missileX.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_missileX.BorderColor = System.Drawing.Color.Black;
+            textBox_missileX.Location = new System.Drawing.Point(98, 74);
+            textBox_missileX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_missileX.Multiline = false;
+            textBox_missileX.Name = "textBox_missileX";
+            textBox_missileX.OnTextChanged = null;
+            textBox_missileX.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_missileX.ReadOnly = false;
+            textBox_missileX.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_missileX.SelectionStart = 0;
+            textBox_missileX.Size = new System.Drawing.Size(47, 23);
+            textBox_missileX.TabIndex = 1;
+            textBox_missileX.Tag = "textBox_missileX";
+            textBox_missileX.WordWrap = true;
+            textBox_missileX.TextChanged += textBox_dropProb_TextChanged;
             // 
             // label_redX
             // 
-            this.label_redX.AutoSize = true;
-            this.label_redX.Location = new System.Drawing.Point(6, 92);
-            this.label_redX.Name = "label_redX";
-            this.label_redX.Size = new System.Drawing.Size(40, 13);
-            this.label_redX.TabIndex = 0;
-            this.label_redX.Text = "Red X:";
+            label_redX.AutoSize = true;
+            label_redX.Location = new System.Drawing.Point(7, 106);
+            label_redX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_redX.Name = "label_redX";
+            label_redX.Size = new System.Drawing.Size(40, 15);
+            label_redX.TabIndex = 0;
+            label_redX.Text = "Red X:";
             // 
             // textBox_healthX
             // 
-            this.textBox_healthX.Location = new System.Drawing.Point(84, 39);
-            this.textBox_healthX.Name = "textBox_healthX";
-            this.textBox_healthX.Size = new System.Drawing.Size(40, 20);
-            this.textBox_healthX.TabIndex = 0;
-            this.textBox_healthX.TextChanged += new System.EventHandler(this.textBox_dropProb_TextChanged);
+            textBox_healthX.BorderColor = System.Drawing.Color.Black;
+            textBox_healthX.Location = new System.Drawing.Point(98, 45);
+            textBox_healthX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_healthX.Multiline = false;
+            textBox_healthX.Name = "textBox_healthX";
+            textBox_healthX.OnTextChanged = null;
+            textBox_healthX.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_healthX.ReadOnly = false;
+            textBox_healthX.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_healthX.SelectionStart = 0;
+            textBox_healthX.Size = new System.Drawing.Size(47, 23);
+            textBox_healthX.TabIndex = 0;
+            textBox_healthX.Tag = "textBox_healthXP";
+            textBox_healthX.WordWrap = true;
+            textBox_healthX.TextChanged += textBox_dropProb_TextChanged;
             // 
             // groupBox_stats
             // 
-            this.groupBox_stats.Controls.Add(this.label_health);
-            this.groupBox_stats.Controls.Add(this.comboBox_reduction);
-            this.groupBox_stats.Controls.Add(this.label_reduction);
-            this.groupBox_stats.Controls.Add(this.textBox_damage);
-            this.groupBox_stats.Controls.Add(this.textBox_health);
-            this.groupBox_stats.Controls.Add(this.label_damage);
-            this.groupBox_stats.Location = new System.Drawing.Point(262, 40);
-            this.groupBox_stats.Name = "groupBox_stats";
-            this.groupBox_stats.Size = new System.Drawing.Size(113, 115);
-            this.groupBox_stats.TabIndex = 2;
-            this.groupBox_stats.TabStop = false;
-            this.groupBox_stats.Text = "Stats";
+            groupBox_stats.Controls.Add(label_health);
+            groupBox_stats.Controls.Add(comboBox_reduction);
+            groupBox_stats.Controls.Add(label_reduction);
+            groupBox_stats.Controls.Add(textBox_damage);
+            groupBox_stats.Controls.Add(textBox_health);
+            groupBox_stats.Controls.Add(label_damage);
+            groupBox_stats.Location = new System.Drawing.Point(306, 46);
+            groupBox_stats.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_stats.Name = "groupBox_stats";
+            groupBox_stats.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_stats.Size = new System.Drawing.Size(132, 133);
+            groupBox_stats.TabIndex = 2;
+            groupBox_stats.TabStop = false;
+            groupBox_stats.Text = "Stats";
             // 
             // label_health
             // 
-            this.label_health.AutoSize = true;
-            this.label_health.Location = new System.Drawing.Point(6, 18);
-            this.label_health.Name = "label_health";
-            this.label_health.Size = new System.Drawing.Size(41, 13);
-            this.label_health.TabIndex = 0;
-            this.label_health.Text = "Health:";
+            label_health.AutoSize = true;
+            label_health.Location = new System.Drawing.Point(7, 21);
+            label_health.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_health.Name = "label_health";
+            label_health.Size = new System.Drawing.Size(45, 15);
+            label_health.TabIndex = 0;
+            label_health.Text = "Health:";
             // 
             // comboBox_reduction
             // 
-            this.comboBox_reduction.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_reduction.FormattingEnabled = true;
-            this.comboBox_reduction.Items.AddRange(new object[] {
-            "30% and 10%",
-            "60% and 30%",
-            "80% and 10%",
-            "90% and 80%"});
-            this.comboBox_reduction.Location = new System.Drawing.Point(9, 86);
-            this.comboBox_reduction.Name = "comboBox_reduction";
-            this.comboBox_reduction.Size = new System.Drawing.Size(95, 21);
-            this.comboBox_reduction.TabIndex = 2;
-            this.comboBox_reduction.SelectedIndexChanged += new System.EventHandler(this.SpriteValueChanged);
+            comboBox_reduction.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_reduction.FormattingEnabled = true;
+            comboBox_reduction.Items.AddRange(new object[] { "30% and 10%", "60% and 30%", "80% and 10%", "90% and 80%" });
+            comboBox_reduction.Location = new System.Drawing.Point(10, 99);
+            comboBox_reduction.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_reduction.Name = "comboBox_reduction";
+            comboBox_reduction.Size = new System.Drawing.Size(110, 23);
+            comboBox_reduction.TabIndex = 2;
+            comboBox_reduction.SelectedIndexChanged += SpriteValueChanged;
             // 
             // label_reduction
             // 
-            this.label_reduction.AutoSize = true;
-            this.label_reduction.Location = new System.Drawing.Point(6, 70);
-            this.label_reduction.Name = "label_reduction";
-            this.label_reduction.Size = new System.Drawing.Size(75, 13);
-            this.label_reduction.TabIndex = 0;
-            this.label_reduction.Text = "Suit reduction:";
+            label_reduction.AutoSize = true;
+            label_reduction.Location = new System.Drawing.Point(7, 81);
+            label_reduction.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_reduction.Name = "label_reduction";
+            label_reduction.Size = new System.Drawing.Size(84, 15);
+            label_reduction.TabIndex = 0;
+            label_reduction.Text = "Suit reduction:";
             // 
             // textBox_damage
             // 
-            this.textBox_damage.Location = new System.Drawing.Point(62, 41);
-            this.textBox_damage.Name = "textBox_damage";
-            this.textBox_damage.Size = new System.Drawing.Size(42, 20);
-            this.textBox_damage.TabIndex = 1;
-            this.textBox_damage.TextChanged += new System.EventHandler(this.SpriteValueChanged);
+            textBox_damage.BorderColor = System.Drawing.Color.Black;
+            textBox_damage.Location = new System.Drawing.Point(72, 47);
+            textBox_damage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_damage.Multiline = false;
+            textBox_damage.Name = "textBox_damage";
+            textBox_damage.OnTextChanged = null;
+            textBox_damage.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_damage.ReadOnly = false;
+            textBox_damage.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_damage.SelectionStart = 0;
+            textBox_damage.Size = new System.Drawing.Size(49, 23);
+            textBox_damage.TabIndex = 1;
+            textBox_damage.WordWrap = true;
+            textBox_damage.TextChanged += SpriteValueChanged;
             // 
             // textBox_health
             // 
-            this.textBox_health.Location = new System.Drawing.Point(62, 15);
-            this.textBox_health.Name = "textBox_health";
-            this.textBox_health.Size = new System.Drawing.Size(42, 20);
-            this.textBox_health.TabIndex = 0;
-            this.textBox_health.TextChanged += new System.EventHandler(this.SpriteValueChanged);
+            textBox_health.BorderColor = System.Drawing.Color.Black;
+            textBox_health.Location = new System.Drawing.Point(72, 17);
+            textBox_health.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_health.Multiline = false;
+            textBox_health.Name = "textBox_health";
+            textBox_health.OnTextChanged = null;
+            textBox_health.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_health.ReadOnly = false;
+            textBox_health.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_health.SelectionStart = 0;
+            textBox_health.Size = new System.Drawing.Size(49, 23);
+            textBox_health.TabIndex = 0;
+            textBox_health.WordWrap = true;
+            textBox_health.TextChanged += SpriteValueChanged;
             // 
             // label_damage
             // 
-            this.label_damage.AutoSize = true;
-            this.label_damage.Location = new System.Drawing.Point(6, 44);
-            this.label_damage.Name = "label_damage";
-            this.label_damage.Size = new System.Drawing.Size(50, 13);
-            this.label_damage.TabIndex = 0;
-            this.label_damage.Text = "Damage:";
+            label_damage.AutoSize = true;
+            label_damage.Location = new System.Drawing.Point(7, 51);
+            label_damage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_damage.Name = "label_damage";
+            label_damage.Size = new System.Drawing.Size(54, 15);
+            label_damage.TabIndex = 0;
+            label_damage.Text = "Damage:";
             // 
             // button_apply
             // 
-            this.button_apply.Enabled = false;
-            this.button_apply.Location = new System.Drawing.Point(219, 278);
-            this.button_apply.Name = "button_apply";
-            this.button_apply.Size = new System.Drawing.Size(75, 23);
-            this.button_apply.TabIndex = 6;
-            this.button_apply.Text = "Apply";
-            this.button_apply.UseVisualStyleBackColor = true;
-            this.button_apply.Click += new System.EventHandler(this.button_apply_Click);
+            button_apply.Enabled = false;
+            button_apply.Location = new System.Drawing.Point(255, 321);
+            button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_apply.Name = "button_apply";
+            button_apply.Size = new System.Drawing.Size(88, 27);
+            button_apply.TabIndex = 6;
+            button_apply.Text = "Apply";
+            button_apply.UseVisualStyleBackColor = true;
+            button_apply.Click += button_apply_Click;
             // 
             // button_close
             // 
-            this.button_close.Location = new System.Drawing.Point(300, 278);
-            this.button_close.Name = "button_close";
-            this.button_close.Size = new System.Drawing.Size(75, 23);
-            this.button_close.TabIndex = 7;
-            this.button_close.Text = "Close";
-            this.button_close.UseVisualStyleBackColor = true;
-            this.button_close.Click += new System.EventHandler(this.button_close_Click);
+            button_close.Location = new System.Drawing.Point(350, 321);
+            button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_close.Name = "button_close";
+            button_close.Size = new System.Drawing.Size(88, 27);
+            button_close.TabIndex = 7;
+            button_close.Text = "Close";
+            button_close.UseVisualStyleBackColor = true;
+            button_close.Click += button_close_Click;
             // 
             // label_sprite
             // 
-            this.label_sprite.AutoSize = true;
-            this.label_sprite.Location = new System.Drawing.Point(262, 16);
-            this.label_sprite.Name = "label_sprite";
-            this.label_sprite.Size = new System.Drawing.Size(37, 13);
-            this.label_sprite.TabIndex = 0;
-            this.label_sprite.Text = "Sprite:";
+            label_sprite.AutoSize = true;
+            label_sprite.Location = new System.Drawing.Point(306, 18);
+            label_sprite.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_sprite.Name = "label_sprite";
+            label_sprite.Size = new System.Drawing.Size(40, 15);
+            label_sprite.TabIndex = 0;
+            label_sprite.Text = "Sprite:";
             // 
             // comboBox_sprite
             // 
-            this.comboBox_sprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_sprite.FormattingEnabled = true;
-            this.comboBox_sprite.Location = new System.Drawing.Point(303, 13);
-            this.comboBox_sprite.Name = "comboBox_sprite";
-            this.comboBox_sprite.Size = new System.Drawing.Size(55, 21);
-            this.comboBox_sprite.TabIndex = 0;
-            this.comboBox_sprite.SelectedIndexChanged += new System.EventHandler(this.comboBox_sprite_SelectedIndexChanged);
+            comboBox_sprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_sprite.FormattingEnabled = true;
+            comboBox_sprite.Location = new System.Drawing.Point(354, 15);
+            comboBox_sprite.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_sprite.Name = "comboBox_sprite";
+            comboBox_sprite.Size = new System.Drawing.Size(63, 23);
+            comboBox_sprite.TabIndex = 0;
+            comboBox_sprite.SelectedIndexChanged += comboBox_sprite_SelectedIndexChanged;
             // 
             // button_editPalette
             // 
-            this.button_editPalette.Location = new System.Drawing.Point(65, 103);
-            this.button_editPalette.Name = "button_editPalette";
-            this.button_editPalette.Size = new System.Drawing.Size(60, 22);
-            this.button_editPalette.TabIndex = 3;
-            this.button_editPalette.Text = "Edit";
-            this.button_editPalette.UseVisualStyleBackColor = true;
-            this.button_editPalette.Click += new System.EventHandler(this.button_editPalette_Click);
+            button_editPalette.Location = new System.Drawing.Point(76, 119);
+            button_editPalette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_editPalette.Name = "button_editPalette";
+            button_editPalette.Size = new System.Drawing.Size(70, 25);
+            button_editPalette.TabIndex = 3;
+            button_editPalette.Text = "Edit";
+            button_editPalette.UseVisualStyleBackColor = true;
+            button_editPalette.Click += button_editPalette_Click;
             // 
             // label_type
             // 
-            this.label_type.AutoSize = true;
-            this.label_type.Location = new System.Drawing.Point(399, 16);
-            this.label_type.Name = "label_type";
-            this.label_type.Size = new System.Drawing.Size(34, 13);
-            this.label_type.TabIndex = 0;
-            this.label_type.Text = "Type:";
+            label_type.AutoSize = true;
+            label_type.Location = new System.Drawing.Point(465, 18);
+            label_type.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_type.Name = "label_type";
+            label_type.Size = new System.Drawing.Size(34, 15);
+            label_type.TabIndex = 0;
+            label_type.Text = "Type:";
             // 
             // comboBox_type
             // 
-            this.comboBox_type.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_type.FormattingEnabled = true;
-            this.comboBox_type.Items.AddRange(new object[] {
-            "Primary",
-            "Secondary"});
-            this.comboBox_type.Location = new System.Drawing.Point(439, 13);
-            this.comboBox_type.Name = "comboBox_type";
-            this.comboBox_type.Size = new System.Drawing.Size(77, 21);
-            this.comboBox_type.TabIndex = 1;
-            this.comboBox_type.SelectedIndexChanged += new System.EventHandler(this.comboBox_type_SelectedIndexChanged);
+            comboBox_type.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_type.FormattingEnabled = true;
+            comboBox_type.Items.AddRange(new object[] { "Primary", "Secondary" });
+            comboBox_type.Location = new System.Drawing.Point(512, 15);
+            comboBox_type.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_type.Name = "comboBox_type";
+            comboBox_type.Size = new System.Drawing.Size(140, 23);
+            comboBox_type.TabIndex = 1;
+            comboBox_type.SelectedIndexChanged += comboBox_type_SelectedIndexChanged;
             // 
             // pictureBox_preview
             // 
-            this.pictureBox_preview.Location = new System.Drawing.Point(0, 0);
-            this.pictureBox_preview.Name = "pictureBox_preview";
-            this.pictureBox_preview.Size = new System.Drawing.Size(215, 101);
-            this.pictureBox_preview.TabIndex = 34;
-            this.pictureBox_preview.TabStop = false;
+            pictureBox_preview.Location = new System.Drawing.Point(0, 0);
+            pictureBox_preview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_preview.Name = "pictureBox_preview";
+            pictureBox_preview.Size = new System.Drawing.Size(251, 117);
+            pictureBox_preview.TabIndex = 34;
+            pictureBox_preview.TabStop = false;
             // 
             // groupBox_preview
             // 
-            this.groupBox_preview.Controls.Add(this.panel_preview);
-            this.groupBox_preview.Location = new System.Drawing.Point(12, 12);
-            this.groupBox_preview.Name = "groupBox_preview";
-            this.groupBox_preview.Size = new System.Drawing.Size(244, 143);
-            this.groupBox_preview.TabIndex = 0;
-            this.groupBox_preview.TabStop = false;
-            this.groupBox_preview.Text = "Preview";
+            groupBox_preview.Controls.Add(panel_preview);
+            groupBox_preview.Location = new System.Drawing.Point(14, 14);
+            groupBox_preview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_preview.Name = "groupBox_preview";
+            groupBox_preview.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_preview.Size = new System.Drawing.Size(285, 165);
+            groupBox_preview.TabIndex = 0;
+            groupBox_preview.TabStop = false;
+            groupBox_preview.Text = "Preview";
             // 
             // panel_preview
             // 
-            this.panel_preview.AutoScroll = true;
-            this.panel_preview.Controls.Add(this.pictureBox_preview);
-            this.panel_preview.Location = new System.Drawing.Point(6, 19);
-            this.panel_preview.Name = "panel_preview";
-            this.panel_preview.Size = new System.Drawing.Size(232, 118);
-            this.panel_preview.TabIndex = 0;
+            panel_preview.AutoScroll = true;
+            panel_preview.Controls.Add(pictureBox_preview);
+            panel_preview.Location = new System.Drawing.Point(7, 22);
+            panel_preview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            panel_preview.Name = "panel_preview";
+            panel_preview.Size = new System.Drawing.Size(271, 136);
+            panel_preview.TabIndex = 0;
             // 
             // textBox_gfxOffsetVal
             // 
-            this.textBox_gfxOffsetVal.Location = new System.Drawing.Point(7, 34);
-            this.textBox_gfxOffsetVal.Name = "textBox_gfxOffsetVal";
-            this.textBox_gfxOffsetVal.Size = new System.Drawing.Size(52, 20);
-            this.textBox_gfxOffsetVal.TabIndex = 0;
-            this.textBox_gfxOffsetVal.TextChanged += new System.EventHandler(this.SpriteValueChanged);
+            textBox_gfxOffsetVal.BorderColor = System.Drawing.Color.Black;
+            textBox_gfxOffsetVal.Location = new System.Drawing.Point(8, 39);
+            textBox_gfxOffsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_gfxOffsetVal.Multiline = false;
+            textBox_gfxOffsetVal.Name = "textBox_gfxOffsetVal";
+            textBox_gfxOffsetVal.OnTextChanged = null;
+            textBox_gfxOffsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_gfxOffsetVal.ReadOnly = false;
+            textBox_gfxOffsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_gfxOffsetVal.SelectionStart = 0;
+            textBox_gfxOffsetVal.Size = new System.Drawing.Size(61, 23);
+            textBox_gfxOffsetVal.TabIndex = 0;
+            textBox_gfxOffsetVal.WordWrap = true;
+            textBox_gfxOffsetVal.TextChanged += SpriteValueChanged;
             // 
             // label_gfxOffset
             // 
-            this.label_gfxOffset.AutoSize = true;
-            this.label_gfxOffset.Location = new System.Drawing.Point(6, 18);
-            this.label_gfxOffset.Name = "label_gfxOffset";
-            this.label_gfxOffset.Size = new System.Drawing.Size(60, 13);
-            this.label_gfxOffset.TabIndex = 0;
-            this.label_gfxOffset.Text = "GFX offset:";
+            label_gfxOffset.AutoSize = true;
+            label_gfxOffset.Location = new System.Drawing.Point(7, 21);
+            label_gfxOffset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_gfxOffset.Name = "label_gfxOffset";
+            label_gfxOffset.Size = new System.Drawing.Size(64, 15);
+            label_gfxOffset.TabIndex = 0;
+            label_gfxOffset.Text = "GFX offset:";
             // 
             // button_editGFX
             // 
-            this.button_editGFX.Location = new System.Drawing.Point(65, 33);
-            this.button_editGFX.Name = "button_editGFX";
-            this.button_editGFX.Size = new System.Drawing.Size(60, 22);
-            this.button_editGFX.TabIndex = 1;
-            this.button_editGFX.Text = "Edit";
-            this.button_editGFX.UseVisualStyleBackColor = true;
-            this.button_editGFX.Click += new System.EventHandler(this.button_editGFX_Click);
+            button_editGFX.Location = new System.Drawing.Point(76, 38);
+            button_editGFX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_editGFX.Name = "button_editGFX";
+            button_editGFX.Size = new System.Drawing.Size(70, 25);
+            button_editGFX.TabIndex = 1;
+            button_editGFX.Text = "Edit";
+            button_editGFX.UseVisualStyleBackColor = true;
+            button_editGFX.Click += button_editGFX_Click;
             // 
             // label_palOffset
             // 
-            this.label_palOffset.AutoSize = true;
-            this.label_palOffset.Location = new System.Drawing.Point(6, 88);
-            this.label_palOffset.Name = "label_palOffset";
-            this.label_palOffset.Size = new System.Drawing.Size(72, 13);
-            this.label_palOffset.TabIndex = 0;
-            this.label_palOffset.Text = "Palette offset:";
+            label_palOffset.AutoSize = true;
+            label_palOffset.Location = new System.Drawing.Point(7, 102);
+            label_palOffset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_palOffset.Name = "label_palOffset";
+            label_palOffset.Size = new System.Drawing.Size(79, 15);
+            label_palOffset.TabIndex = 0;
+            label_palOffset.Text = "Palette offset:";
             // 
             // textBox_palOffsetVal
             // 
-            this.textBox_palOffsetVal.Location = new System.Drawing.Point(7, 104);
-            this.textBox_palOffsetVal.Name = "textBox_palOffsetVal";
-            this.textBox_palOffsetVal.Size = new System.Drawing.Size(52, 20);
-            this.textBox_palOffsetVal.TabIndex = 2;
-            this.textBox_palOffsetVal.TextChanged += new System.EventHandler(this.SpriteValueChanged);
+            textBox_palOffsetVal.BorderColor = System.Drawing.Color.Black;
+            textBox_palOffsetVal.Location = new System.Drawing.Point(8, 120);
+            textBox_palOffsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_palOffsetVal.Multiline = false;
+            textBox_palOffsetVal.Name = "textBox_palOffsetVal";
+            textBox_palOffsetVal.OnTextChanged = null;
+            textBox_palOffsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_palOffsetVal.ReadOnly = false;
+            textBox_palOffsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_palOffsetVal.SelectionStart = 0;
+            textBox_palOffsetVal.Size = new System.Drawing.Size(61, 23);
+            textBox_palOffsetVal.TabIndex = 2;
+            textBox_palOffsetVal.WordWrap = true;
+            textBox_palOffsetVal.TextChanged += SpriteValueChanged;
             // 
             // groupBox_graphics
             // 
-            this.groupBox_graphics.Controls.Add(this.numericUpDown_gfxRows);
-            this.groupBox_graphics.Controls.Add(this.label_gfxOffset);
-            this.groupBox_graphics.Controls.Add(this.label_gfxRows);
-            this.groupBox_graphics.Controls.Add(this.label_palOffset);
-            this.groupBox_graphics.Controls.Add(this.button_editPalette);
-            this.groupBox_graphics.Controls.Add(this.textBox_palOffsetVal);
-            this.groupBox_graphics.Controls.Add(this.textBox_gfxOffsetVal);
-            this.groupBox_graphics.Controls.Add(this.button_editGFX);
-            this.groupBox_graphics.Location = new System.Drawing.Point(12, 161);
-            this.groupBox_graphics.Name = "groupBox_graphics";
-            this.groupBox_graphics.Size = new System.Drawing.Size(131, 131);
-            this.groupBox_graphics.TabIndex = 4;
-            this.groupBox_graphics.TabStop = false;
-            this.groupBox_graphics.Text = "Graphics";
-            // 
-            // label_AI
-            // 
-            this.label_AI.AutoSize = true;
-            this.label_AI.Location = new System.Drawing.Point(149, 275);
-            this.label_AI.Name = "label_AI";
-            this.label_AI.Size = new System.Drawing.Size(49, 13);
-            this.label_AI.TabIndex = 0;
-            this.label_AI.Text = "AI offset:";
-            // 
-            // textBox_AIoffset
-            // 
-            this.textBox_AIoffset.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_AIoffset.Location = new System.Drawing.Point(152, 291);
-            this.textBox_AIoffset.Name = "textBox_AIoffset";
-            this.textBox_AIoffset.ReadOnly = true;
-            this.textBox_AIoffset.Size = new System.Drawing.Size(55, 13);
-            this.textBox_AIoffset.TabIndex = 0;
-            this.textBox_AIoffset.TabStop = false;
-            this.textBox_AIoffset.Text = "000000";
-            // 
-            // statusStrip
-            // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusLabel_changes});
-            this.statusStrip.Location = new System.Drawing.Point(0, 310);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(528, 22);
-            this.statusStrip.TabIndex = 8;
-            // 
-            // statusLabel_changes
-            // 
-            this.statusLabel_changes.Name = "statusLabel_changes";
-            this.statusLabel_changes.Size = new System.Drawing.Size(12, 17);
-            this.statusLabel_changes.Text = "-";
-            // 
-            // label_gfxRows
-            // 
-            this.label_gfxRows.AutoSize = true;
-            this.label_gfxRows.Location = new System.Drawing.Point(6, 63);
-            this.label_gfxRows.Name = "label_gfxRows";
-            this.label_gfxRows.Size = new System.Drawing.Size(56, 13);
-            this.label_gfxRows.TabIndex = 9;
-            this.label_gfxRows.Text = "GFX rows:";
+            groupBox_graphics.Controls.Add(numericUpDown_gfxRows);
+            groupBox_graphics.Controls.Add(label_gfxOffset);
+            groupBox_graphics.Controls.Add(label_gfxRows);
+            groupBox_graphics.Controls.Add(label_palOffset);
+            groupBox_graphics.Controls.Add(button_editPalette);
+            groupBox_graphics.Controls.Add(textBox_palOffsetVal);
+            groupBox_graphics.Controls.Add(textBox_gfxOffsetVal);
+            groupBox_graphics.Controls.Add(button_editGFX);
+            groupBox_graphics.Location = new System.Drawing.Point(14, 186);
+            groupBox_graphics.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_graphics.Name = "groupBox_graphics";
+            groupBox_graphics.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_graphics.Size = new System.Drawing.Size(153, 151);
+            groupBox_graphics.TabIndex = 4;
+            groupBox_graphics.TabStop = false;
+            groupBox_graphics.Text = "Graphics";
             // 
             // numericUpDown_gfxRows
             // 
-            this.numericUpDown_gfxRows.Location = new System.Drawing.Point(68, 61);
-            this.numericUpDown_gfxRows.Maximum = new decimal(new int[] {
-            8,
-            0,
-            0,
-            0});
-            this.numericUpDown_gfxRows.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numericUpDown_gfxRows.Name = "numericUpDown_gfxRows";
-            this.numericUpDown_gfxRows.Size = new System.Drawing.Size(35, 20);
-            this.numericUpDown_gfxRows.TabIndex = 10;
-            this.numericUpDown_gfxRows.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numericUpDown_gfxRows.ValueChanged += new System.EventHandler(this.SpriteValueChanged);
+            numericUpDown_gfxRows.Location = new System.Drawing.Point(79, 70);
+            numericUpDown_gfxRows.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown_gfxRows.Maximum = new decimal(new int[] { 8, 0, 0, 0 });
+            numericUpDown_gfxRows.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numericUpDown_gfxRows.Name = "numericUpDown_gfxRows";
+            numericUpDown_gfxRows.Size = new System.Drawing.Size(41, 23);
+            numericUpDown_gfxRows.TabIndex = 10;
+            numericUpDown_gfxRows.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            numericUpDown_gfxRows.ValueChanged += SpriteValueChanged;
+            // 
+            // label_gfxRows
+            // 
+            label_gfxRows.AutoSize = true;
+            label_gfxRows.Location = new System.Drawing.Point(7, 73);
+            label_gfxRows.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_gfxRows.Name = "label_gfxRows";
+            label_gfxRows.Size = new System.Drawing.Size(59, 15);
+            label_gfxRows.TabIndex = 9;
+            label_gfxRows.Text = "GFX rows:";
+            // 
+            // label_AI
+            // 
+            label_AI.AutoSize = true;
+            label_AI.Location = new System.Drawing.Point(174, 317);
+            label_AI.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_AI.Name = "label_AI";
+            label_AI.Size = new System.Drawing.Size(54, 15);
+            label_AI.TabIndex = 0;
+            label_AI.Text = "AI offset:";
+            // 
+            // textBox_AIoffset
+            // 
+            textBox_AIoffset.BorderColor = System.Drawing.Color.Black;
+            textBox_AIoffset.Location = new System.Drawing.Point(177, 336);
+            textBox_AIoffset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_AIoffset.Multiline = false;
+            textBox_AIoffset.Name = "textBox_AIoffset";
+            textBox_AIoffset.OnTextChanged = null;
+            textBox_AIoffset.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_AIoffset.ReadOnly = true;
+            textBox_AIoffset.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_AIoffset.SelectionStart = 0;
+            textBox_AIoffset.Size = new System.Drawing.Size(64, 23);
+            textBox_AIoffset.TabIndex = 0;
+            textBox_AIoffset.TabStop = false;
+            textBox_AIoffset.WordWrap = true;
+            // 
+            // statusStrip
+            // 
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes });
+            statusStrip.Location = new System.Drawing.Point(0, 361);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip.Size = new System.Drawing.Size(660, 22);
+            statusStrip.TabIndex = 8;
+            // 
+            // statusLabel_changes
+            // 
+            statusLabel_changes.Name = "statusLabel_changes";
+            statusLabel_changes.Size = new System.Drawing.Size(12, 17);
+            statusLabel_changes.Text = "-";
             // 
             // FormSprite
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(528, 332);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.textBox_AIoffset);
-            this.Controls.Add(this.label_AI);
-            this.Controls.Add(this.groupBox_graphics);
-            this.Controls.Add(this.groupBox_preview);
-            this.Controls.Add(this.comboBox_type);
-            this.Controls.Add(this.label_type);
-            this.Controls.Add(this.comboBox_sprite);
-            this.Controls.Add(this.label_sprite);
-            this.Controls.Add(this.button_close);
-            this.Controls.Add(this.button_apply);
-            this.Controls.Add(this.groupBox_stats);
-            this.Controls.Add(this.groupBox_dropProbability);
-            this.Controls.Add(this.groupBox_vulnerability);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "FormSprite";
-            this.Text = "Sprite Editor";
-            this.groupBox_vulnerability.ResumeLayout(false);
-            this.groupBox_vulnerability.PerformLayout();
-            this.groupBox_dropProbability.ResumeLayout(false);
-            this.groupBox_dropProbability.PerformLayout();
-            this.groupBox_stats.ResumeLayout(false);
-            this.groupBox_stats.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_preview)).EndInit();
-            this.groupBox_preview.ResumeLayout(false);
-            this.panel_preview.ResumeLayout(false);
-            this.groupBox_graphics.ResumeLayout(false);
-            this.groupBox_graphics.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown_gfxRows)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(660, 383);
+            Controls.Add(statusStrip);
+            Controls.Add(textBox_AIoffset);
+            Controls.Add(label_AI);
+            Controls.Add(groupBox_graphics);
+            Controls.Add(groupBox_preview);
+            Controls.Add(comboBox_type);
+            Controls.Add(label_type);
+            Controls.Add(comboBox_sprite);
+            Controls.Add(label_sprite);
+            Controls.Add(button_close);
+            Controls.Add(button_apply);
+            Controls.Add(groupBox_stats);
+            Controls.Add(groupBox_dropProbability);
+            Controls.Add(groupBox_vulnerability);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "FormSprite";
+            Text = "Sprite Editor";
+            groupBox_vulnerability.ResumeLayout(false);
+            groupBox_vulnerability.PerformLayout();
+            groupBox_dropProbability.ResumeLayout(false);
+            groupBox_dropProbability.PerformLayout();
+            panel_percentage.ResumeLayout(false);
+            groupBox_stats.ResumeLayout(false);
+            groupBox_stats.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_preview).EndInit();
+            groupBox_preview.ResumeLayout(false);
+            panel_preview.ResumeLayout(false);
+            groupBox_graphics.ResumeLayout(false);
+            groupBox_graphics.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown_gfxRows).EndInit();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -795,5 +1149,16 @@
         private System.Windows.Forms.ToolStripStatusLabel statusLabel_changes;
         private mage.Theming.CustomControls.FlatNumericUpDown numericUpDown_gfxRows;
         private System.Windows.Forms.Label label_gfxRows;
+        private Theming.CustomControls.FlatTextBox textBox_powerBombP;
+        private Theming.CustomControls.FlatTextBox textBox_superMissileP;
+        private Theming.CustomControls.FlatTextBox textBox_missileP;
+        private Theming.CustomControls.FlatTextBox textBox_largeHealthP;
+        private Theming.CustomControls.FlatTextBox textBox_smallHealthP;
+        private Theming.CustomControls.FlatTextBox textBox_noDropP;
+        private Theming.CustomControls.FlatTextBox textBox_redXP;
+        private Theming.CustomControls.FlatTextBox textBox_missileXP;
+        private Theming.CustomControls.FlatTextBox textBox_healthXP;
+        private System.Windows.Forms.Label label_totalPercent;
+        private System.Windows.Forms.Panel panel_percentage;
     }
 }

--- a/mage/Editors/FormSprite.cs
+++ b/mage/Editors/FormSprite.cs
@@ -1,4 +1,5 @@
 ﻿using mage.Theming;
+using mage.Theming.CustomControls;
 using System;
 using System.Drawing;
 using System.Windows.Forms;
@@ -272,7 +273,7 @@ namespace mage
             {
                 foreach (Control ctrl in controls)
                 {
-                    if (ctrl is TextBox && ctrl.Enabled)
+                    if (ctrl is FlatTextBox && ctrl.Enabled)
                     {
                         total += Hex.ToUshort(ctrl.Text);
                     }

--- a/mage/Editors/FormSprite.resx
+++ b/mage/Editors/FormSprite.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>43</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAEBAAAAAAGABoAwAAJgAAACAgAAAAABgAqAwAAI4DAAAoAAAAEAAAACAAAAABABgAAAAAAAAD

--- a/mage/Editors/FormText.Designer.cs
+++ b/mage/Editors/FormText.Designer.cs
@@ -29,328 +29,360 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormText));
-            this.comboBox_language = new mage.Theming.CustomControls.FlatComboBox();
-            this.label_language = new System.Windows.Forms.Label();
-            this.label_number = new System.Windows.Forms.Label();
-            this.comboBox_number = new mage.Theming.CustomControls.FlatComboBox();
-            this.pictureBox_text = new System.Windows.Forms.PictureBox();
-            this.checkBox_newLine = new System.Windows.Forms.CheckBox();
-            this.checkBox_wordWrap = new System.Windows.Forms.CheckBox();
-            this.label_text = new System.Windows.Forms.Label();
-            this.comboBox_text = new mage.Theming.CustomControls.FlatComboBox();
-            this.textBox_offsetVal = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_offset = new System.Windows.Forms.Label();
-            this.panel_gfx = new System.Windows.Forms.Panel();
-            this.groupBox_options = new System.Windows.Forms.GroupBox();
-            this.label_charPos = new System.Windows.Forms.Label();
-            this.label_pos = new System.Windows.Forms.Label();
-            this.button_close = new System.Windows.Forms.Button();
-            this.button_apply = new System.Windows.Forms.Button();
-            this.groupBox_preview = new System.Windows.Forms.GroupBox();
-            this.button_editGfx = new System.Windows.Forms.Button();
-            this.button_update = new System.Windows.Forms.Button();
-            this.button_editPalette = new System.Windows.Forms.Button();
-            this.pictureBox_palette = new System.Windows.Forms.PictureBox();
-            this.textBox = new mage.Theming.CustomControls.FlatTextBox();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_text)).BeginInit();
-            this.panel_gfx.SuspendLayout();
-            this.groupBox_options.SuspendLayout();
-            this.groupBox_preview.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_palette)).BeginInit();
-            this.statusStrip.SuspendLayout();
-            this.SuspendLayout();
+            comboBox_language = new Theming.CustomControls.FlatComboBox();
+            label_language = new System.Windows.Forms.Label();
+            label_number = new System.Windows.Forms.Label();
+            comboBox_number = new Theming.CustomControls.FlatComboBox();
+            pictureBox_text = new System.Windows.Forms.PictureBox();
+            checkBox_newLine = new System.Windows.Forms.CheckBox();
+            checkBox_wordWrap = new System.Windows.Forms.CheckBox();
+            label_text = new System.Windows.Forms.Label();
+            comboBox_text = new Theming.CustomControls.FlatComboBox();
+            textBox_offsetVal = new Theming.CustomControls.FlatTextBox();
+            label_offset = new System.Windows.Forms.Label();
+            panel_gfx = new System.Windows.Forms.Panel();
+            groupBox_options = new System.Windows.Forms.GroupBox();
+            label_charPos = new System.Windows.Forms.Label();
+            label_pos = new System.Windows.Forms.Label();
+            button_close = new System.Windows.Forms.Button();
+            button_apply = new System.Windows.Forms.Button();
+            groupBox_preview = new System.Windows.Forms.GroupBox();
+            button_editGfx = new System.Windows.Forms.Button();
+            button_update = new System.Windows.Forms.Button();
+            button_editPalette = new System.Windows.Forms.Button();
+            pictureBox_palette = new System.Windows.Forms.PictureBox();
+            textBox = new Theming.CustomControls.FlatTextBox();
+            statusStrip = new System.Windows.Forms.StatusStrip();
+            statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_text).BeginInit();
+            panel_gfx.SuspendLayout();
+            groupBox_options.SuspendLayout();
+            groupBox_preview.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBox_palette).BeginInit();
+            statusStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // comboBox_language
             // 
-            this.comboBox_language.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_language.FormattingEnabled = true;
-            this.comboBox_language.Location = new System.Drawing.Point(70, 46);
-            this.comboBox_language.Name = "comboBox_language";
-            this.comboBox_language.Size = new System.Drawing.Size(90, 21);
-            this.comboBox_language.TabIndex = 1;
-            this.comboBox_language.SelectedIndexChanged += new System.EventHandler(this.comboBox_language_SelectedIndexChanged);
+            comboBox_language.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_language.FormattingEnabled = true;
+            comboBox_language.Location = new System.Drawing.Point(82, 53);
+            comboBox_language.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_language.Name = "comboBox_language";
+            comboBox_language.Size = new System.Drawing.Size(104, 23);
+            comboBox_language.TabIndex = 1;
+            comboBox_language.SelectedIndexChanged += comboBox_language_SelectedIndexChanged;
             // 
             // label_language
             // 
-            this.label_language.AutoSize = true;
-            this.label_language.Location = new System.Drawing.Point(6, 49);
-            this.label_language.Name = "label_language";
-            this.label_language.Size = new System.Drawing.Size(58, 13);
-            this.label_language.TabIndex = 0;
-            this.label_language.Text = "Language:";
+            label_language.AutoSize = true;
+            label_language.Location = new System.Drawing.Point(7, 57);
+            label_language.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_language.Name = "label_language";
+            label_language.Size = new System.Drawing.Size(62, 15);
+            label_language.TabIndex = 0;
+            label_language.Text = "Language:";
             // 
             // label_number
             // 
-            this.label_number.AutoSize = true;
-            this.label_number.Location = new System.Drawing.Point(6, 76);
-            this.label_number.Name = "label_number";
-            this.label_number.Size = new System.Drawing.Size(47, 13);
-            this.label_number.TabIndex = 0;
-            this.label_number.Text = "Number:";
+            label_number.AutoSize = true;
+            label_number.Location = new System.Drawing.Point(7, 88);
+            label_number.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_number.Name = "label_number";
+            label_number.Size = new System.Drawing.Size(54, 15);
+            label_number.TabIndex = 0;
+            label_number.Text = "Number:";
             // 
             // comboBox_number
             // 
-            this.comboBox_number.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_number.FormattingEnabled = true;
-            this.comboBox_number.Location = new System.Drawing.Point(70, 73);
-            this.comboBox_number.Name = "comboBox_number";
-            this.comboBox_number.Size = new System.Drawing.Size(49, 21);
-            this.comboBox_number.TabIndex = 2;
-            this.comboBox_number.SelectedIndexChanged += new System.EventHandler(this.comboBox_number_SelectedIndexChanged);
+            comboBox_number.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_number.FormattingEnabled = true;
+            comboBox_number.Location = new System.Drawing.Point(82, 84);
+            comboBox_number.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_number.Name = "comboBox_number";
+            comboBox_number.Size = new System.Drawing.Size(56, 23);
+            comboBox_number.TabIndex = 2;
+            comboBox_number.SelectedIndexChanged += comboBox_number_SelectedIndexChanged;
             // 
             // pictureBox_text
             // 
-            this.pictureBox_text.Location = new System.Drawing.Point(0, 0);
-            this.pictureBox_text.Name = "pictureBox_text";
-            this.pictureBox_text.Size = new System.Drawing.Size(240, 80);
-            this.pictureBox_text.TabIndex = 5;
-            this.pictureBox_text.TabStop = false;
+            pictureBox_text.Location = new System.Drawing.Point(0, 0);
+            pictureBox_text.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_text.Name = "pictureBox_text";
+            pictureBox_text.Size = new System.Drawing.Size(280, 92);
+            pictureBox_text.TabIndex = 5;
+            pictureBox_text.TabStop = false;
             // 
             // checkBox_newLine
             // 
-            this.checkBox_newLine.AutoSize = true;
-            this.checkBox_newLine.Location = new System.Drawing.Point(176, 46);
-            this.checkBox_newLine.Name = "checkBox_newLine";
-            this.checkBox_newLine.Size = new System.Drawing.Size(94, 17);
-            this.checkBox_newLine.TabIndex = 4;
-            this.checkBox_newLine.Text = "Mark newlines";
-            this.checkBox_newLine.UseVisualStyleBackColor = true;
-            this.checkBox_newLine.CheckedChanged += new System.EventHandler(this.checkBox_newLine_CheckedChanged);
+            checkBox_newLine.AutoSize = true;
+            checkBox_newLine.Location = new System.Drawing.Point(205, 53);
+            checkBox_newLine.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_newLine.Name = "checkBox_newLine";
+            checkBox_newLine.Size = new System.Drawing.Size(102, 19);
+            checkBox_newLine.TabIndex = 4;
+            checkBox_newLine.Text = "Mark newlines";
+            checkBox_newLine.UseVisualStyleBackColor = true;
+            checkBox_newLine.CheckedChanged += checkBox_newLine_CheckedChanged;
             // 
             // checkBox_wordWrap
             // 
-            this.checkBox_wordWrap.AutoSize = true;
-            this.checkBox_wordWrap.Checked = true;
-            this.checkBox_wordWrap.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox_wordWrap.Location = new System.Drawing.Point(176, 19);
-            this.checkBox_wordWrap.Name = "checkBox_wordWrap";
-            this.checkBox_wordWrap.Size = new System.Drawing.Size(78, 17);
-            this.checkBox_wordWrap.TabIndex = 3;
-            this.checkBox_wordWrap.Text = "Word wrap";
-            this.checkBox_wordWrap.UseVisualStyleBackColor = true;
-            this.checkBox_wordWrap.CheckedChanged += new System.EventHandler(this.checkBox_wordWrap_CheckedChanged);
+            checkBox_wordWrap.AutoSize = true;
+            checkBox_wordWrap.Checked = true;
+            checkBox_wordWrap.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox_wordWrap.Location = new System.Drawing.Point(205, 22);
+            checkBox_wordWrap.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_wordWrap.Name = "checkBox_wordWrap";
+            checkBox_wordWrap.Size = new System.Drawing.Size(84, 19);
+            checkBox_wordWrap.TabIndex = 3;
+            checkBox_wordWrap.Text = "Word wrap";
+            checkBox_wordWrap.UseVisualStyleBackColor = true;
+            checkBox_wordWrap.CheckedChanged += checkBox_wordWrap_CheckedChanged;
             // 
             // label_text
             // 
-            this.label_text.AutoSize = true;
-            this.label_text.Location = new System.Drawing.Point(6, 22);
-            this.label_text.Name = "label_text";
-            this.label_text.Size = new System.Drawing.Size(31, 13);
-            this.label_text.TabIndex = 0;
-            this.label_text.Text = "Text:";
+            label_text.AutoSize = true;
+            label_text.Location = new System.Drawing.Point(7, 25);
+            label_text.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_text.Name = "label_text";
+            label_text.Size = new System.Drawing.Size(31, 15);
+            label_text.TabIndex = 0;
+            label_text.Text = "Text:";
             // 
             // comboBox_text
             // 
-            this.comboBox_text.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_text.FormattingEnabled = true;
-            this.comboBox_text.Location = new System.Drawing.Point(70, 19);
-            this.comboBox_text.Name = "comboBox_text";
-            this.comboBox_text.Size = new System.Drawing.Size(90, 21);
-            this.comboBox_text.TabIndex = 0;
-            this.comboBox_text.SelectedIndexChanged += new System.EventHandler(this.comboBox_text_SelectedIndexChanged);
+            comboBox_text.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_text.FormattingEnabled = true;
+            comboBox_text.Location = new System.Drawing.Point(82, 22);
+            comboBox_text.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_text.Name = "comboBox_text";
+            comboBox_text.Size = new System.Drawing.Size(104, 23);
+            comboBox_text.TabIndex = 0;
+            comboBox_text.SelectedIndexChanged += comboBox_text_SelectedIndexChanged;
             // 
             // textBox_offsetVal
             // 
-            this.textBox_offsetVal.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox_offsetVal.Location = new System.Drawing.Point(50, 103);
-            this.textBox_offsetVal.Name = "textBox_offsetVal";
-            this.textBox_offsetVal.ReadOnly = true;
-            this.textBox_offsetVal.Size = new System.Drawing.Size(55, 13);
-            this.textBox_offsetVal.TabIndex = 0;
-            this.textBox_offsetVal.TabStop = false;
-            this.textBox_offsetVal.Text = "000000";
+            textBox_offsetVal.BorderColor = System.Drawing.Color.Black;
+            textBox_offsetVal.Location = new System.Drawing.Point(58, 119);
+            textBox_offsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_offsetVal.Multiline = false;
+            textBox_offsetVal.Name = "textBox_offsetVal";
+            textBox_offsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_offsetVal.ReadOnly = true;
+            textBox_offsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_offsetVal.SelectionStart = 0;
+            textBox_offsetVal.Size = new System.Drawing.Size(64, 23);
+            textBox_offsetVal.TabIndex = 0;
+            textBox_offsetVal.TabStop = false;
+            textBox_offsetVal.WordWrap = true;
             // 
             // label_offset
             // 
-            this.label_offset.AutoSize = true;
-            this.label_offset.Location = new System.Drawing.Point(6, 103);
-            this.label_offset.Name = "label_offset";
-            this.label_offset.Size = new System.Drawing.Size(38, 13);
-            this.label_offset.TabIndex = 0;
-            this.label_offset.Text = "Offset:";
+            label_offset.AutoSize = true;
+            label_offset.Location = new System.Drawing.Point(7, 119);
+            label_offset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_offset.Name = "label_offset";
+            label_offset.Size = new System.Drawing.Size(42, 15);
+            label_offset.TabIndex = 0;
+            label_offset.Text = "Offset:";
             // 
             // panel_gfx
             // 
-            this.panel_gfx.AutoScroll = true;
-            this.panel_gfx.Controls.Add(this.pictureBox_text);
-            this.panel_gfx.Location = new System.Drawing.Point(6, 41);
-            this.panel_gfx.Name = "panel_gfx";
-            this.panel_gfx.Size = new System.Drawing.Size(257, 80);
-            this.panel_gfx.TabIndex = 32;
+            panel_gfx.AutoScroll = true;
+            panel_gfx.Controls.Add(pictureBox_text);
+            panel_gfx.Location = new System.Drawing.Point(7, 47);
+            panel_gfx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            panel_gfx.Name = "panel_gfx";
+            panel_gfx.Size = new System.Drawing.Size(300, 92);
+            panel_gfx.TabIndex = 32;
             // 
             // groupBox_options
             // 
-            this.groupBox_options.Controls.Add(this.label_charPos);
-            this.groupBox_options.Controls.Add(this.label_pos);
-            this.groupBox_options.Controls.Add(this.button_close);
-            this.groupBox_options.Controls.Add(this.button_apply);
-            this.groupBox_options.Controls.Add(this.comboBox_text);
-            this.groupBox_options.Controls.Add(this.comboBox_language);
-            this.groupBox_options.Controls.Add(this.textBox_offsetVal);
-            this.groupBox_options.Controls.Add(this.label_language);
-            this.groupBox_options.Controls.Add(this.label_offset);
-            this.groupBox_options.Controls.Add(this.comboBox_number);
-            this.groupBox_options.Controls.Add(this.label_text);
-            this.groupBox_options.Controls.Add(this.label_number);
-            this.groupBox_options.Controls.Add(this.checkBox_newLine);
-            this.groupBox_options.Controls.Add(this.checkBox_wordWrap);
-            this.groupBox_options.Location = new System.Drawing.Point(12, 12);
-            this.groupBox_options.Name = "groupBox_options";
-            this.groupBox_options.Size = new System.Drawing.Size(282, 127);
-            this.groupBox_options.TabIndex = 0;
-            this.groupBox_options.TabStop = false;
-            this.groupBox_options.Text = "Options";
+            groupBox_options.Controls.Add(label_charPos);
+            groupBox_options.Controls.Add(label_pos);
+            groupBox_options.Controls.Add(button_close);
+            groupBox_options.Controls.Add(button_apply);
+            groupBox_options.Controls.Add(comboBox_text);
+            groupBox_options.Controls.Add(comboBox_language);
+            groupBox_options.Controls.Add(textBox_offsetVal);
+            groupBox_options.Controls.Add(label_language);
+            groupBox_options.Controls.Add(label_offset);
+            groupBox_options.Controls.Add(comboBox_number);
+            groupBox_options.Controls.Add(label_text);
+            groupBox_options.Controls.Add(label_number);
+            groupBox_options.Controls.Add(checkBox_newLine);
+            groupBox_options.Controls.Add(checkBox_wordWrap);
+            groupBox_options.Location = new System.Drawing.Point(14, 14);
+            groupBox_options.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_options.Name = "groupBox_options";
+            groupBox_options.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_options.Size = new System.Drawing.Size(329, 147);
+            groupBox_options.TabIndex = 0;
+            groupBox_options.TabStop = false;
+            groupBox_options.Text = "Options";
             // 
             // label_charPos
             // 
-            this.label_charPos.AutoSize = true;
-            this.label_charPos.Location = new System.Drawing.Point(173, 73);
-            this.label_charPos.Name = "label_charPos";
-            this.label_charPos.Size = new System.Drawing.Size(56, 13);
-            this.label_charPos.TabIndex = 0;
-            this.label_charPos.Text = "Character:";
+            label_charPos.AutoSize = true;
+            label_charPos.Location = new System.Drawing.Point(202, 84);
+            label_charPos.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_charPos.Name = "label_charPos";
+            label_charPos.Size = new System.Drawing.Size(61, 15);
+            label_charPos.TabIndex = 0;
+            label_charPos.Text = "Character:";
             // 
             // label_pos
             // 
-            this.label_pos.AutoSize = true;
-            this.label_pos.Location = new System.Drawing.Point(235, 73);
-            this.label_pos.Name = "label_pos";
-            this.label_pos.Size = new System.Drawing.Size(13, 13);
-            this.label_pos.TabIndex = 0;
-            this.label_pos.Text = "0";
+            label_pos.AutoSize = true;
+            label_pos.Location = new System.Drawing.Point(274, 84);
+            label_pos.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_pos.Name = "label_pos";
+            label_pos.Size = new System.Drawing.Size(13, 15);
+            label_pos.TabIndex = 0;
+            label_pos.Text = "0";
             // 
             // button_close
             // 
-            this.button_close.Location = new System.Drawing.Point(206, 98);
-            this.button_close.Name = "button_close";
-            this.button_close.Size = new System.Drawing.Size(70, 23);
-            this.button_close.TabIndex = 6;
-            this.button_close.Text = "Close";
-            this.button_close.UseVisualStyleBackColor = true;
-            this.button_close.Click += new System.EventHandler(this.button_close_Click);
+            button_close.Location = new System.Drawing.Point(240, 113);
+            button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_close.Name = "button_close";
+            button_close.Size = new System.Drawing.Size(82, 27);
+            button_close.TabIndex = 6;
+            button_close.Text = "Close";
+            button_close.UseVisualStyleBackColor = true;
+            button_close.Click += button_close_Click;
             // 
             // button_apply
             // 
-            this.button_apply.Enabled = false;
-            this.button_apply.Location = new System.Drawing.Point(130, 98);
-            this.button_apply.Name = "button_apply";
-            this.button_apply.Size = new System.Drawing.Size(70, 23);
-            this.button_apply.TabIndex = 5;
-            this.button_apply.Text = "Apply";
-            this.button_apply.UseVisualStyleBackColor = true;
-            this.button_apply.Click += new System.EventHandler(this.button_apply_Click);
+            button_apply.Enabled = false;
+            button_apply.Location = new System.Drawing.Point(152, 113);
+            button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_apply.Name = "button_apply";
+            button_apply.Size = new System.Drawing.Size(82, 27);
+            button_apply.TabIndex = 5;
+            button_apply.Text = "Apply";
+            button_apply.UseVisualStyleBackColor = true;
+            button_apply.Click += button_apply_Click;
             // 
             // groupBox_preview
             // 
-            this.groupBox_preview.Controls.Add(this.button_editGfx);
-            this.groupBox_preview.Controls.Add(this.button_update);
-            this.groupBox_preview.Controls.Add(this.button_editPalette);
-            this.groupBox_preview.Controls.Add(this.pictureBox_palette);
-            this.groupBox_preview.Controls.Add(this.panel_gfx);
-            this.groupBox_preview.Location = new System.Drawing.Point(300, 12);
-            this.groupBox_preview.Name = "groupBox_preview";
-            this.groupBox_preview.Size = new System.Drawing.Size(335, 127);
-            this.groupBox_preview.TabIndex = 1;
-            this.groupBox_preview.TabStop = false;
-            this.groupBox_preview.Text = "Preview";
+            groupBox_preview.Controls.Add(button_editGfx);
+            groupBox_preview.Controls.Add(button_update);
+            groupBox_preview.Controls.Add(button_editPalette);
+            groupBox_preview.Controls.Add(pictureBox_palette);
+            groupBox_preview.Controls.Add(panel_gfx);
+            groupBox_preview.Location = new System.Drawing.Point(350, 14);
+            groupBox_preview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_preview.Name = "groupBox_preview";
+            groupBox_preview.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_preview.Size = new System.Drawing.Size(391, 147);
+            groupBox_preview.TabIndex = 1;
+            groupBox_preview.TabStop = false;
+            groupBox_preview.Text = "Preview";
             // 
             // button_editGfx
             // 
-            this.button_editGfx.Location = new System.Drawing.Point(269, 100);
-            this.button_editGfx.Name = "button_editGfx";
-            this.button_editGfx.Size = new System.Drawing.Size(60, 21);
-            this.button_editGfx.TabIndex = 2;
-            this.button_editGfx.Text = "Edit GFX";
-            this.button_editGfx.UseVisualStyleBackColor = true;
-            this.button_editGfx.Click += new System.EventHandler(this.button_editGfx_Click);
+            button_editGfx.Location = new System.Drawing.Point(314, 115);
+            button_editGfx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_editGfx.Name = "button_editGfx";
+            button_editGfx.Size = new System.Drawing.Size(70, 24);
+            button_editGfx.TabIndex = 2;
+            button_editGfx.Text = "Edit GFX";
+            button_editGfx.UseVisualStyleBackColor = true;
+            button_editGfx.Click += button_editGfx_Click;
             // 
             // button_update
             // 
-            this.button_update.Location = new System.Drawing.Point(269, 41);
-            this.button_update.Name = "button_update";
-            this.button_update.Size = new System.Drawing.Size(60, 55);
-            this.button_update.TabIndex = 1;
-            this.button_update.Text = "Update";
-            this.button_update.UseVisualStyleBackColor = true;
-            this.button_update.Click += new System.EventHandler(this.button_update_Click);
+            button_update.Location = new System.Drawing.Point(314, 47);
+            button_update.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_update.Name = "button_update";
+            button_update.Size = new System.Drawing.Size(70, 63);
+            button_update.TabIndex = 1;
+            button_update.Text = "Update";
+            button_update.UseVisualStyleBackColor = true;
+            button_update.Click += button_update_Click;
             // 
             // button_editPalette
             // 
-            this.button_editPalette.Location = new System.Drawing.Point(269, 16);
-            this.button_editPalette.Name = "button_editPalette";
-            this.button_editPalette.Size = new System.Drawing.Size(60, 21);
-            this.button_editPalette.TabIndex = 0;
-            this.button_editPalette.Text = "Edit";
-            this.button_editPalette.UseVisualStyleBackColor = true;
-            this.button_editPalette.Click += new System.EventHandler(this.button_editPalette_Click);
+            button_editPalette.Location = new System.Drawing.Point(314, 18);
+            button_editPalette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_editPalette.Name = "button_editPalette";
+            button_editPalette.Size = new System.Drawing.Size(70, 24);
+            button_editPalette.TabIndex = 0;
+            button_editPalette.Text = "Edit";
+            button_editPalette.UseVisualStyleBackColor = true;
+            button_editPalette.Click += button_editPalette_Click;
             // 
             // pictureBox_palette
             // 
-            this.pictureBox_palette.Location = new System.Drawing.Point(6, 18);
-            this.pictureBox_palette.Name = "pictureBox_palette";
-            this.pictureBox_palette.Size = new System.Drawing.Size(257, 17);
-            this.pictureBox_palette.TabIndex = 35;
-            this.pictureBox_palette.TabStop = false;
+            pictureBox_palette.Location = new System.Drawing.Point(7, 21);
+            pictureBox_palette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBox_palette.Name = "pictureBox_palette";
+            pictureBox_palette.Size = new System.Drawing.Size(300, 20);
+            pictureBox_palette.TabIndex = 35;
+            pictureBox_palette.TabStop = false;
             // 
             // textBox
             // 
-            this.textBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox.Font = new System.Drawing.Font("Courier New", 9.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textBox.Location = new System.Drawing.Point(12, 145);
-            this.textBox.Multiline = true;
-            this.textBox.Name = "textBox";
-            this.textBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.textBox.Size = new System.Drawing.Size(623, 188);
-            this.textBox.TabIndex = 0;
-            this.textBox.TabStop = false;
-            this.textBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox_MouseClick);
-            this.textBox.TextChanged += new System.EventHandler(this.textBox_TextChanged);
-            this.textBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.textBox_KeyUp);
+            textBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            textBox.BorderColor = System.Drawing.Color.Black;
+            textBox.Font = new System.Drawing.Font("Courier New", 9.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            textBox.Location = new System.Drawing.Point(14, 167);
+            textBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox.Multiline = true;
+            textBox.Name = "textBox";
+            textBox.Padding = new System.Windows.Forms.Padding(4, 3, 4, 2);
+            textBox.ReadOnly = false;
+            textBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            textBox.SelectionStart = 0;
+            textBox.Size = new System.Drawing.Size(727, 221);
+            textBox.TabIndex = 0;
+            textBox.TabStop = false;
+            textBox.WordWrap = true;
+            textBox.TextChanged += textBox_TextChanged;
+            textBox.KeyUp += textBox_KeyUp;
+            textBox.MouseClick += textBox_MouseClick;
             // 
             // statusStrip
             // 
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusLabel_changes});
-            this.statusStrip.Location = new System.Drawing.Point(0, 336);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.Size = new System.Drawing.Size(647, 22);
-            this.statusStrip.TabIndex = 2;
-            this.statusStrip.Text = "statusStrip";
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes });
+            statusStrip.Location = new System.Drawing.Point(0, 391);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip.Size = new System.Drawing.Size(755, 22);
+            statusStrip.TabIndex = 2;
+            statusStrip.Text = "statusStrip";
             // 
             // statusLabel_changes
             // 
-            this.statusLabel_changes.Name = "statusLabel_changes";
-            this.statusLabel_changes.Size = new System.Drawing.Size(12, 17);
-            this.statusLabel_changes.Text = "-";
+            statusLabel_changes.Name = "statusLabel_changes";
+            statusLabel_changes.Size = new System.Drawing.Size(12, 17);
+            statusLabel_changes.Text = "-";
             // 
             // FormText
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(647, 358);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.groupBox_preview);
-            this.Controls.Add(this.groupBox_options);
-            this.Controls.Add(this.textBox);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MinimumSize = new System.Drawing.Size(663, 397);
-            this.Name = "FormText";
-            this.Text = "Text Editor";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_text)).EndInit();
-            this.panel_gfx.ResumeLayout(false);
-            this.groupBox_options.ResumeLayout(false);
-            this.groupBox_options.PerformLayout();
-            this.groupBox_preview.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox_palette)).EndInit();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(755, 413);
+            Controls.Add(statusStrip);
+            Controls.Add(groupBox_preview);
+            Controls.Add(groupBox_options);
+            Controls.Add(textBox);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MinimumSize = new System.Drawing.Size(771, 452);
+            Name = "FormText";
+            Text = "Text Editor";
+            ((System.ComponentModel.ISupportInitialize)pictureBox_text).EndInit();
+            panel_gfx.ResumeLayout(false);
+            groupBox_options.ResumeLayout(false);
+            groupBox_options.PerformLayout();
+            groupBox_preview.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)pictureBox_palette).EndInit();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/mage/Editors/FormText.Designer.cs
+++ b/mage/Editors/FormText.Designer.cs
@@ -33,15 +33,15 @@
             label_language = new System.Windows.Forms.Label();
             label_number = new System.Windows.Forms.Label();
             comboBox_number = new Theming.CustomControls.FlatComboBox();
-            pictureBox_text = new System.Windows.Forms.PictureBox();
+            pictureBox_text = new GfxView();
             checkBox_newLine = new System.Windows.Forms.CheckBox();
             checkBox_wordWrap = new System.Windows.Forms.CheckBox();
             label_text = new System.Windows.Forms.Label();
             comboBox_text = new Theming.CustomControls.FlatComboBox();
-            textBox_offsetVal = new Theming.CustomControls.FlatTextBox();
             label_offset = new System.Windows.Forms.Label();
             panel_gfx = new System.Windows.Forms.Panel();
             groupBox_options = new System.Windows.Forms.GroupBox();
+            textBox_offsetVal = new Theming.CustomControls.FlatTextBox();
             label_charPos = new System.Windows.Forms.Label();
             label_pos = new System.Windows.Forms.Label();
             button_close = new System.Windows.Forms.Button();
@@ -54,12 +54,24 @@
             textBox = new Theming.CustomControls.FlatTextBox();
             statusStrip = new System.Windows.Forms.StatusStrip();
             statusLabel_changes = new System.Windows.Forms.ToolStripStatusLabel();
-            ((System.ComponentModel.ISupportInitialize)pictureBox_text).BeginInit();
+            spring = new System.Windows.Forms.ToolStripStatusLabel();
+            label_zoom = new System.Windows.Forms.ToolStripStatusLabel();
+            button_zoom = new System.Windows.Forms.ToolStripDropDownButton();
+            button_zoom1600 = new System.Windows.Forms.ToolStripMenuItem();
+            button_zoom800 = new System.Windows.Forms.ToolStripMenuItem();
+            button_zoom400 = new System.Windows.Forms.ToolStripMenuItem();
+            button_zoom200 = new System.Windows.Forms.ToolStripMenuItem();
+            button_zoom100 = new System.Windows.Forms.ToolStripMenuItem();
+            splitContainer = new System.Windows.Forms.SplitContainer();
             panel_gfx.SuspendLayout();
             groupBox_options.SuspendLayout();
             groupBox_preview.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pictureBox_palette).BeginInit();
             statusStrip.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer).BeginInit();
+            splitContainer.Panel1.SuspendLayout();
+            splitContainer.Panel2.SuspendLayout();
+            splitContainer.SuspendLayout();
             SuspendLayout();
             // 
             // comboBox_language
@@ -106,10 +118,11 @@
             // 
             // pictureBox_text
             // 
+            pictureBox_text.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             pictureBox_text.Location = new System.Drawing.Point(0, 0);
             pictureBox_text.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             pictureBox_text.Name = "pictureBox_text";
-            pictureBox_text.Size = new System.Drawing.Size(280, 92);
+            pictureBox_text.Size = new System.Drawing.Size(275, 99);
             pictureBox_text.TabIndex = 5;
             pictureBox_text.TabStop = false;
             // 
@@ -160,22 +173,6 @@
             comboBox_text.TabIndex = 0;
             comboBox_text.SelectedIndexChanged += comboBox_text_SelectedIndexChanged;
             // 
-            // textBox_offsetVal
-            // 
-            textBox_offsetVal.BorderColor = System.Drawing.Color.Black;
-            textBox_offsetVal.Location = new System.Drawing.Point(58, 119);
-            textBox_offsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            textBox_offsetVal.Multiline = false;
-            textBox_offsetVal.Name = "textBox_offsetVal";
-            textBox_offsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
-            textBox_offsetVal.ReadOnly = true;
-            textBox_offsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
-            textBox_offsetVal.SelectionStart = 0;
-            textBox_offsetVal.Size = new System.Drawing.Size(64, 23);
-            textBox_offsetVal.TabIndex = 0;
-            textBox_offsetVal.TabStop = false;
-            textBox_offsetVal.WordWrap = true;
-            // 
             // label_offset
             // 
             label_offset.AutoSize = true;
@@ -188,23 +185,25 @@
             // 
             // panel_gfx
             // 
+            panel_gfx.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             panel_gfx.AutoScroll = true;
             panel_gfx.Controls.Add(pictureBox_text);
             panel_gfx.Location = new System.Drawing.Point(7, 47);
             panel_gfx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             panel_gfx.Name = "panel_gfx";
-            panel_gfx.Size = new System.Drawing.Size(300, 92);
+            panel_gfx.Size = new System.Drawing.Size(295, 99);
             panel_gfx.TabIndex = 32;
             // 
             // groupBox_options
             // 
+            groupBox_options.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox_options.Controls.Add(textBox_offsetVal);
             groupBox_options.Controls.Add(label_charPos);
             groupBox_options.Controls.Add(label_pos);
             groupBox_options.Controls.Add(button_close);
             groupBox_options.Controls.Add(button_apply);
             groupBox_options.Controls.Add(comboBox_text);
             groupBox_options.Controls.Add(comboBox_language);
-            groupBox_options.Controls.Add(textBox_offsetVal);
             groupBox_options.Controls.Add(label_language);
             groupBox_options.Controls.Add(label_offset);
             groupBox_options.Controls.Add(comboBox_number);
@@ -212,14 +211,30 @@
             groupBox_options.Controls.Add(label_number);
             groupBox_options.Controls.Add(checkBox_newLine);
             groupBox_options.Controls.Add(checkBox_wordWrap);
-            groupBox_options.Location = new System.Drawing.Point(14, 14);
+            groupBox_options.Location = new System.Drawing.Point(13, 12);
             groupBox_options.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_options.Name = "groupBox_options";
             groupBox_options.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox_options.Size = new System.Drawing.Size(329, 147);
+            groupBox_options.Size = new System.Drawing.Size(335, 154);
             groupBox_options.TabIndex = 0;
             groupBox_options.TabStop = false;
             groupBox_options.Text = "Options";
+            // 
+            // textBox_offsetVal
+            // 
+            textBox_offsetVal.BorderColor = System.Drawing.Color.FromArgb(188, 188, 188);
+            textBox_offsetVal.Location = new System.Drawing.Point(57, 115);
+            textBox_offsetVal.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_offsetVal.Multiline = false;
+            textBox_offsetVal.Name = "textBox_offsetVal";
+            textBox_offsetVal.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_offsetVal.ReadOnly = true;
+            textBox_offsetVal.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_offsetVal.SelectionStart = 0;
+            textBox_offsetVal.Size = new System.Drawing.Size(64, 23);
+            textBox_offsetVal.TabIndex = 7;
+            textBox_offsetVal.TabStop = false;
+            textBox_offsetVal.WordWrap = true;
             // 
             // label_charPos
             // 
@@ -266,23 +281,25 @@
             // 
             // groupBox_preview
             // 
+            groupBox_preview.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             groupBox_preview.Controls.Add(button_editGfx);
             groupBox_preview.Controls.Add(button_update);
             groupBox_preview.Controls.Add(button_editPalette);
             groupBox_preview.Controls.Add(pictureBox_palette);
             groupBox_preview.Controls.Add(panel_gfx);
-            groupBox_preview.Location = new System.Drawing.Point(350, 14);
+            groupBox_preview.Location = new System.Drawing.Point(356, 12);
             groupBox_preview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_preview.Name = "groupBox_preview";
             groupBox_preview.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox_preview.Size = new System.Drawing.Size(391, 147);
+            groupBox_preview.Size = new System.Drawing.Size(386, 154);
             groupBox_preview.TabIndex = 1;
             groupBox_preview.TabStop = false;
             groupBox_preview.Text = "Preview";
             // 
             // button_editGfx
             // 
-            button_editGfx.Location = new System.Drawing.Point(314, 115);
+            button_editGfx.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button_editGfx.Location = new System.Drawing.Point(309, 115);
             button_editGfx.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_editGfx.Name = "button_editGfx";
             button_editGfx.Size = new System.Drawing.Size(70, 24);
@@ -293,7 +310,8 @@
             // 
             // button_update
             // 
-            button_update.Location = new System.Drawing.Point(314, 47);
+            button_update.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button_update.Location = new System.Drawing.Point(309, 47);
             button_update.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_update.Name = "button_update";
             button_update.Size = new System.Drawing.Size(70, 63);
@@ -304,7 +322,8 @@
             // 
             // button_editPalette
             // 
-            button_editPalette.Location = new System.Drawing.Point(314, 18);
+            button_editPalette.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button_editPalette.Location = new System.Drawing.Point(309, 18);
             button_editPalette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_editPalette.Name = "button_editPalette";
             button_editPalette.Size = new System.Drawing.Size(70, 24);
@@ -315,10 +334,11 @@
             // 
             // pictureBox_palette
             // 
+            pictureBox_palette.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             pictureBox_palette.Location = new System.Drawing.Point(7, 21);
             pictureBox_palette.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             pictureBox_palette.Name = "pictureBox_palette";
-            pictureBox_palette.Size = new System.Drawing.Size(300, 20);
+            pictureBox_palette.Size = new System.Drawing.Size(295, 20);
             pictureBox_palette.TabIndex = 35;
             pictureBox_palette.TabStop = false;
             // 
@@ -327,7 +347,7 @@
             textBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             textBox.BorderColor = System.Drawing.Color.Black;
             textBox.Font = new System.Drawing.Font("Courier New", 9.5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            textBox.Location = new System.Drawing.Point(14, 167);
+            textBox.Location = new System.Drawing.Point(13, 3);
             textBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox.Multiline = true;
             textBox.Name = "textBox";
@@ -335,7 +355,7 @@
             textBox.ReadOnly = false;
             textBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             textBox.SelectionStart = 0;
-            textBox.Size = new System.Drawing.Size(727, 221);
+            textBox.Size = new System.Drawing.Size(729, 284);
             textBox.TabIndex = 0;
             textBox.TabStop = false;
             textBox.WordWrap = true;
@@ -345,8 +365,8 @@
             // 
             // statusStrip
             // 
-            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes });
-            statusStrip.Location = new System.Drawing.Point(0, 391);
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_changes, spring, label_zoom, button_zoom });
+            statusStrip.Location = new System.Drawing.Point(0, 471);
             statusStrip.Name = "statusStrip";
             statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
             statusStrip.Size = new System.Drawing.Size(755, 22);
@@ -359,21 +379,96 @@
             statusLabel_changes.Size = new System.Drawing.Size(12, 17);
             statusLabel_changes.Text = "-";
             // 
+            // spring
+            // 
+            spring.Name = "spring";
+            spring.Size = new System.Drawing.Size(662, 17);
+            spring.Spring = true;
+            // 
+            // label_zoom
+            // 
+            label_zoom.Name = "label_zoom";
+            label_zoom.Size = new System.Drawing.Size(35, 17);
+            label_zoom.Text = "100%";
+            // 
+            // button_zoom
+            // 
+            button_zoom.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            button_zoom.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            button_zoom.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { button_zoom1600, button_zoom800, button_zoom400, button_zoom200, button_zoom100 });
+            button_zoom.Image = Properties.Resources.toolbar_zoom;
+            button_zoom.ImageTransparentColor = System.Drawing.Color.Magenta;
+            button_zoom.Name = "button_zoom";
+            button_zoom.Size = new System.Drawing.Size(29, 20);
+            button_zoom.Text = "Zoom";
+            // 
+            // button_zoom1600
+            // 
+            button_zoom1600.Name = "button_zoom1600";
+            button_zoom1600.Size = new System.Drawing.Size(108, 22);
+            button_zoom1600.Text = "1600%";
+            button_zoom1600.Click += button_zoom1600_Click;
+            // 
+            // button_zoom800
+            // 
+            button_zoom800.Name = "button_zoom800";
+            button_zoom800.Size = new System.Drawing.Size(108, 22);
+            button_zoom800.Text = "800%";
+            button_zoom800.Click += button_zoom800_Click;
+            // 
+            // button_zoom400
+            // 
+            button_zoom400.Name = "button_zoom400";
+            button_zoom400.Size = new System.Drawing.Size(108, 22);
+            button_zoom400.Text = "400%";
+            button_zoom400.Click += button_zoom400_Click;
+            // 
+            // button_zoom200
+            // 
+            button_zoom200.Name = "button_zoom200";
+            button_zoom200.Size = new System.Drawing.Size(108, 22);
+            button_zoom200.Text = "200%";
+            button_zoom200.Click += button_zoom200_Click;
+            // 
+            // button_zoom100
+            // 
+            button_zoom100.Name = "button_zoom100";
+            button_zoom100.Size = new System.Drawing.Size(108, 22);
+            button_zoom100.Text = "100%";
+            button_zoom100.Click += button_zoom100_Click;
+            // 
+            // splitContainer
+            // 
+            splitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer.Location = new System.Drawing.Point(0, 0);
+            splitContainer.Margin = new System.Windows.Forms.Padding(6);
+            splitContainer.Name = "splitContainer";
+            splitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer.Panel1
+            // 
+            splitContainer.Panel1.Controls.Add(groupBox_options);
+            splitContainer.Panel1.Controls.Add(groupBox_preview);
+            // 
+            // splitContainer.Panel2
+            // 
+            splitContainer.Panel2.Controls.Add(textBox);
+            splitContainer.Size = new System.Drawing.Size(755, 471);
+            splitContainer.SplitterDistance = 177;
+            splitContainer.TabIndex = 3;
+            // 
             // FormText
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(755, 413);
+            ClientSize = new System.Drawing.Size(755, 493);
+            Controls.Add(splitContainer);
             Controls.Add(statusStrip);
-            Controls.Add(groupBox_preview);
-            Controls.Add(groupBox_options);
-            Controls.Add(textBox);
             Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
             Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             MinimumSize = new System.Drawing.Size(771, 452);
             Name = "FormText";
             Text = "Text Editor";
-            ((System.ComponentModel.ISupportInitialize)pictureBox_text).EndInit();
             panel_gfx.ResumeLayout(false);
             groupBox_options.ResumeLayout(false);
             groupBox_options.PerformLayout();
@@ -381,6 +476,10 @@
             ((System.ComponentModel.ISupportInitialize)pictureBox_palette).EndInit();
             statusStrip.ResumeLayout(false);
             statusStrip.PerformLayout();
+            splitContainer.Panel1.ResumeLayout(false);
+            splitContainer.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainer).EndInit();
+            splitContainer.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -391,12 +490,11 @@
         private System.Windows.Forms.Label label_language;
         private System.Windows.Forms.Label label_number;
         private mage.Theming.CustomControls.FlatComboBox comboBox_number;
-        private System.Windows.Forms.PictureBox pictureBox_text;
+        private mage.GfxView pictureBox_text;
         private System.Windows.Forms.CheckBox checkBox_newLine;
         private System.Windows.Forms.CheckBox checkBox_wordWrap;
         private System.Windows.Forms.Label label_text;
         private mage.Theming.CustomControls.FlatComboBox comboBox_text;
-        private mage.Theming.CustomControls.FlatTextBox textBox_offsetVal;
         private System.Windows.Forms.Label label_offset;
         private System.Windows.Forms.Panel panel_gfx;
         private System.Windows.Forms.GroupBox groupBox_options;
@@ -412,5 +510,15 @@
         private System.Windows.Forms.Button button_editGfx;
         private System.Windows.Forms.StatusStrip statusStrip;
         private System.Windows.Forms.ToolStripStatusLabel statusLabel_changes;
+        private System.Windows.Forms.ToolStripStatusLabel spring;
+        private System.Windows.Forms.ToolStripDropDownButton button_zoom;
+        private System.Windows.Forms.ToolStripStatusLabel label_zoom;
+        private System.Windows.Forms.ToolStripMenuItem button_zoom1600;
+        private System.Windows.Forms.ToolStripMenuItem button_zoom800;
+        private System.Windows.Forms.ToolStripMenuItem button_zoom400;
+        private System.Windows.Forms.ToolStripMenuItem button_zoom200;
+        private System.Windows.Forms.ToolStripMenuItem button_zoom100;
+        private System.Windows.Forms.SplitContainer splitContainer;
+        private Theming.CustomControls.FlatTextBox textBox_offsetVal;
     }
 }

--- a/mage/Editors/FormText.cs
+++ b/mage/Editors/FormText.cs
@@ -33,6 +33,8 @@ namespace mage
         private Status status;
         private bool loading;
 
+        private int zoom = 0;
+
         // constructor
         public FormText(FormMain main)
         {
@@ -265,8 +267,8 @@ namespace mage
             textImg.UnlockBits(imgData);
 
             pictureBox_text.BackColor = palette.GetOpaqueColor(0, 0);
-            pictureBox_text.Image = textImg;
-            pictureBox_text.Size = textImg.Size;
+            pictureBox_text.BackgroundImage = textImg;
+            pictureBox_text.Size = new Size(textImg.Size.Width << zoom, textImg.Size.Height << zoom);
         }
 
         private bool ParseText()
@@ -462,6 +464,44 @@ namespace mage
             Close();
         }
 
+        private void UpdateZoom()
+        {
+            pictureBox_text.Size = new Size(pictureBox_text.BackgroundImage.Width << zoom, pictureBox_text.BackgroundImage.Height << zoom);
+        }
 
+        private void button_zoom100_Click(object sender, EventArgs e)
+        {
+            zoom = 0;
+            label_zoom.Text = "100%";
+            UpdateZoom();
+        }
+
+        private void button_zoom200_Click(object sender, EventArgs e)
+        {
+            zoom = 1;
+            label_zoom.Text = "200%";
+            UpdateZoom();
+        }
+
+        private void button_zoom400_Click(object sender, EventArgs e)
+        {
+            zoom = 2;
+            label_zoom.Text = "400%";
+            UpdateZoom();
+        }
+
+        private void button_zoom800_Click(object sender, EventArgs e)
+        {
+            zoom = 3;
+            label_zoom.Text = "800%";
+            UpdateZoom();
+        }
+
+        private void button_zoom1600_Click(object sender, EventArgs e)
+        {
+            zoom = 4;
+            label_zoom.Text = "1600%";
+            UpdateZoom();
+        }
     }
 }

--- a/mage/Editors/FormText.cs
+++ b/mage/Editors/FormText.cs
@@ -110,7 +110,7 @@ namespace mage
             // get palette and draw
             palette = new Palette(romStream, Version.TextPaletteOffset, 1);
             pictureBox_palette.Image = palette.Draw(15, 0, 1);
-            
+
             comboBox_language.SelectedIndex = 2;
             comboBox_text.SelectedIndex = 0;
         }
@@ -156,7 +156,8 @@ namespace mage
                     int ctrl = val >> 8;
                     if (ctrl == 0x80) { display += "[INDENT=" + Hex.ToString((byte)val) + "]"; }
                     else if (ctrl == 0x81) { display += "[COLOR=" + Hex.ToString((byte)val % 0xF) + "]"; }
-                    else if (val >> 12 == 9) { display += "[MUSIC=" + Hex.ToString(val & 0xFFF) + "]"; }
+                    else if (val >> 12 == 0x9) { display += "[MUSIC=" + Hex.ToString(val & 0xFFF) + "]"; }
+                    else if (val >> 12 == 0xA) { display += "[MUSIC_STOP=" + Hex.ToString(val & 0xFFF) + "]"; }
                     else if (ctrl == 0xE1) { display += "[DELAY=" + Hex.ToString((byte)val) + "]"; }
                     else if (ctrl == 0xFD) { display += "[NEXT]\r\n"; }
                     else if (ctrl == 0xFE)
@@ -310,9 +311,10 @@ namespace mage
                             else if (strs[0] == "INDENT") { textVals.Add((ushort)(0x8000 + Hex.ToByte(strs[1]))); }
                             else if (strs[0] == "MUSIC") { textVals.Add((ushort)(0x9000 + Hex.ToUshort(strs[1]))); }
                             else if (strs[0] == "DELAY") { textVals.Add((ushort)(0xE100 + Hex.ToUshort(strs[1]))); }
+                            else if (strs[0] == "MUSIC_STOP") { textVals.Add((ushort)(0xA000 + Hex.ToUshort(strs[1]))); }
                             else
                             {
-                                MessageBox.Show("Text could not be parsed.\r\nThe contents of the brackets at character " 
+                                MessageBox.Show("Text could not be parsed.\r\nThe contents of the brackets at character "
                                     + Hex.ToString(i) + " are not valid.", "Parsing Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                                 return false;
                             }
@@ -324,7 +326,7 @@ namespace mage
                         if (text[++i] == '\n') { textVals.Add(0xFE00); }
                         else
                         {
-                            MessageBox.Show("Text could not be parsed.\r\nInvalid newline at character " 
+                            MessageBox.Show("Text could not be parsed.\r\nInvalid newline at character "
                                 + Hex.ToString(i) + ".", "Parsing Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             return false;
                         }
@@ -339,19 +341,19 @@ namespace mage
             }
             catch (IndexOutOfRangeException)
             {
-                MessageBox.Show("Text could not be parsed.\r\nMake sure brackets are closed.", 
+                MessageBox.Show("Text could not be parsed.\r\nMake sure brackets are closed.",
                     "Parsing Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             catch (KeyNotFoundException)
             {
-                MessageBox.Show("Text could not be parsed.\r\nCharacter " 
+                MessageBox.Show("Text could not be parsed.\r\nCharacter "
                     + Hex.ToString(i) + " was not recognized.", "Parsing Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             catch (FormatException)
             {
-                MessageBox.Show("Text could not be parsed.\r\nThe value starting at character " 
+                MessageBox.Show("Text could not be parsed.\r\nThe value starting at character "
                     + Hex.ToString(i) + " is not valid.", "Parsing Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
@@ -444,7 +446,7 @@ namespace mage
             int language = comboBox_language.SelectedIndex;
             int number = comboBox_number.SelectedIndex;
             int pointer = romStream.ReadPtr(textLists[type].offset + language * 4) + number * 4;
-            
+
             // write new data
             romStream.Write(dataToWrite, prevLen * 2, pointer, false);
 

--- a/mage/Editors/FormText.resx
+++ b/mage/Editors/FormText.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAEBAAAAAAGABoAwAAJgAAACAgAAAAABgAqAwAAI4DAAAoAAAAEAAAACAAAAABABgAAAAAAAAD

--- a/mage/FormAbout.cs
+++ b/mage/FormAbout.cs
@@ -17,12 +17,12 @@ namespace mage
 
         private void linkLabel_forum_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(linkLabel_forum.Text);
+            Process.Start(new ProcessStartInfo(linkLabel_forum.Text) { UseShellExecute = true });
         }
 
         private void linkLabel_silk_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(linkLabel_silk.Text);
+            Process.Start(new ProcessStartInfo(linkLabel_silk.Text) { UseShellExecute = true });
         }
 
     }

--- a/mage/FormEditDoor.Designer.cs
+++ b/mage/FormEditDoor.Designer.cs
@@ -270,6 +270,7 @@
             checkBox_autoConnect.Size = new System.Drawing.Size(188, 19);
             checkBox_autoConnect.TabIndex = 5;
             checkBox_autoConnect.Text = "Auto connect destination door";
+            checkBox_autoConnect.CheckedChanged += checkBox_autoConnect_CheckedChanged;
             // 
             // comboBox_type
             // 

--- a/mage/FormEditDoor.Designer.cs
+++ b/mage/FormEditDoor.Designer.cs
@@ -59,6 +59,8 @@
             label_area = new System.Windows.Forms.Label();
             groupBox_info = new System.Windows.Forms.GroupBox();
             groupBox_edit = new System.Windows.Forms.GroupBox();
+            button_preset_x = new System.Windows.Forms.Button();
+            button_preset_y = new System.Windows.Forms.Button();
             textBox_yExitDistance = new Theming.CustomControls.FlatTextBox();
             label_yExitDistance = new System.Windows.Forms.Label();
             statusStrip = new System.Windows.Forms.StatusStrip();
@@ -70,10 +72,10 @@
             // 
             // button_close
             // 
-            button_close.Location = new System.Drawing.Point(274, 255);
+            button_close.Location = new System.Drawing.Point(292, 253);
             button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_close.Name = "button_close";
-            button_close.Size = new System.Drawing.Size(88, 27);
+            button_close.Size = new System.Drawing.Size(86, 27);
             button_close.TabIndex = 1;
             button_close.Text = "Close";
             button_close.UseVisualStyleBackColor = true;
@@ -82,10 +84,10 @@
             // button_apply
             // 
             button_apply.Enabled = false;
-            button_apply.Location = new System.Drawing.Point(274, 222);
+            button_apply.Location = new System.Drawing.Point(292, 220);
             button_apply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_apply.Name = "button_apply";
-            button_apply.Size = new System.Drawing.Size(88, 27);
+            button_apply.Size = new System.Drawing.Size(86, 27);
             button_apply.TabIndex = 0;
             button_apply.Text = "Apply";
             button_apply.UseVisualStyleBackColor = true;
@@ -186,7 +188,7 @@
             // textBox_connectedDoor
             // 
             textBox_connectedDoor.BorderColor = System.Drawing.Color.Black;
-            textBox_connectedDoor.Location = new System.Drawing.Point(298, 52);
+            textBox_connectedDoor.Location = new System.Drawing.Point(312, 52);
             textBox_connectedDoor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox_connectedDoor.Multiline = false;
             textBox_connectedDoor.Name = "textBox_connectedDoor";
@@ -202,7 +204,7 @@
             // textBox_xExitDistance
             // 
             textBox_xExitDistance.BorderColor = System.Drawing.Color.Black;
-            textBox_xExitDistance.Location = new System.Drawing.Point(298, 82);
+            textBox_xExitDistance.Location = new System.Drawing.Point(312, 82);
             textBox_xExitDistance.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox_xExitDistance.Multiline = false;
             textBox_xExitDistance.Name = "textBox_xExitDistance";
@@ -238,7 +240,7 @@
             // textBox_ownerRoom
             // 
             textBox_ownerRoom.BorderColor = System.Drawing.Color.Black;
-            textBox_ownerRoom.Location = new System.Drawing.Point(298, 22);
+            textBox_ownerRoom.Location = new System.Drawing.Point(312, 22);
             textBox_ownerRoom.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox_ownerRoom.Multiline = false;
             textBox_ownerRoom.Name = "textBox_ownerRoom";
@@ -264,7 +266,7 @@
             // checkBox_autoConnect
             // 
             checkBox_autoConnect.AutoSize = true;
-            checkBox_autoConnect.Location = new System.Drawing.Point(145, 142);
+            checkBox_autoConnect.Location = new System.Drawing.Point(165, 140);
             checkBox_autoConnect.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             checkBox_autoConnect.Name = "checkBox_autoConnect";
             checkBox_autoConnect.Size = new System.Drawing.Size(188, 19);
@@ -414,6 +416,8 @@
             // 
             // groupBox_edit
             // 
+            groupBox_edit.Controls.Add(button_preset_x);
+            groupBox_edit.Controls.Add(button_preset_y);
             groupBox_edit.Controls.Add(textBox_yExitDistance);
             groupBox_edit.Controls.Add(label_yExitDistance);
             groupBox_edit.Controls.Add(comboBox_type);
@@ -435,15 +439,35 @@
             groupBox_edit.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_edit.Name = "groupBox_edit";
             groupBox_edit.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox_edit.Size = new System.Drawing.Size(348, 168);
+            groupBox_edit.Size = new System.Drawing.Size(364, 168);
             groupBox_edit.TabIndex = 0;
             groupBox_edit.TabStop = false;
             groupBox_edit.Text = "Edit";
             // 
+            // button_preset_x
+            // 
+            button_preset_x.Image = Properties.Resources.toolbar_connection;
+            button_preset_x.Location = new System.Drawing.Point(282, 82);
+            button_preset_x.Name = "button_preset_x";
+            button_preset_x.Size = new System.Drawing.Size(23, 23);
+            button_preset_x.TabIndex = 18;
+            button_preset_x.UseVisualStyleBackColor = true;
+            button_preset_x.Click += button_preset_x_Click;
+            // 
+            // button_preset_y
+            // 
+            button_preset_y.Image = Properties.Resources.toolbar_connection;
+            button_preset_y.Location = new System.Drawing.Point(282, 112);
+            button_preset_y.Name = "button_preset_y";
+            button_preset_y.Size = new System.Drawing.Size(23, 23);
+            button_preset_y.TabIndex = 17;
+            button_preset_y.UseVisualStyleBackColor = true;
+            button_preset_y.Click += button_preset_y_Click;
+            // 
             // textBox_yExitDistance
             // 
             textBox_yExitDistance.BorderColor = System.Drawing.Color.Black;
-            textBox_yExitDistance.Location = new System.Drawing.Point(298, 112);
+            textBox_yExitDistance.Location = new System.Drawing.Point(312, 112);
             textBox_yExitDistance.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox_yExitDistance.Multiline = false;
             textBox_yExitDistance.Name = "textBox_yExitDistance";
@@ -472,7 +496,7 @@
             statusStrip.Location = new System.Drawing.Point(0, 288);
             statusStrip.Name = "statusStrip";
             statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
-            statusStrip.Size = new System.Drawing.Size(376, 22);
+            statusStrip.Size = new System.Drawing.Size(393, 22);
             statusStrip.TabIndex = 3;
             statusStrip.Text = "statusStrip1";
             // 
@@ -486,7 +510,7 @@
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(376, 310);
+            ClientSize = new System.Drawing.Size(393, 310);
             Controls.Add(statusStrip);
             Controls.Add(groupBox_edit);
             Controls.Add(groupBox_info);
@@ -545,5 +569,7 @@
         private System.Windows.Forms.Label label_yExitDistance;
         private System.Windows.Forms.StatusStrip statusStrip;
         private System.Windows.Forms.ToolStripStatusLabel statusLabel_changes;
+        private System.Windows.Forms.Button button_preset_y;
+        private System.Windows.Forms.Button button_preset_x;
     }
 }

--- a/mage/FormEditDoor.cs
+++ b/mage/FormEditDoor.cs
@@ -317,5 +317,21 @@ namespace mage
             if (!checkBox_autoConnect.Checked) return;
             ValueChanged(sender, e);
         }
+
+        private void button_preset_x_Click(object sender, EventArgs e)
+        {
+            var Dialog = new FormEditDoorPresets(true);
+            Dialog.ShowDialog();
+            if (Dialog.DialogResult != DialogResult.OK) return;
+            textBox_xExitDistance.Text = Hex.ToString(Dialog.Result);
+        }
+
+        private void button_preset_y_Click(object sender, EventArgs e)
+        {
+            var Dialog = new FormEditDoorPresets(false);
+            Dialog.ShowDialog();
+            if (Dialog.DialogResult != DialogResult.OK) return;
+            textBox_yExitDistance.Text = Hex.ToString(Dialog.Result);
+        }
     }
 }

--- a/mage/FormEditDoor.cs
+++ b/mage/FormEditDoor.cs
@@ -311,5 +311,11 @@ namespace mage
         {
             Close();
         }
+
+        private void checkBox_autoConnect_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!checkBox_autoConnect.Checked) return;
+            ValueChanged(sender, e);
+        }
     }
 }

--- a/mage/FormEditDoorPresets.Designer.cs
+++ b/mage/FormEditDoorPresets.Designer.cs
@@ -1,0 +1,172 @@
+﻿namespace mage
+{
+    partial class FormEditDoorPresets
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            button_x_n1 = new System.Windows.Forms.Button();
+            button_x_n2 = new System.Windows.Forms.Button();
+            button_x1 = new System.Windows.Forms.Button();
+            button_x2 = new System.Windows.Forms.Button();
+            pictureBox1 = new System.Windows.Forms.PictureBox();
+            button_y2 = new System.Windows.Forms.Button();
+            button_y1 = new System.Windows.Forms.Button();
+            button_y_n2 = new System.Windows.Forms.Button();
+            button_y_n1 = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
+            SuspendLayout();
+            // 
+            // button_x_n1
+            // 
+            button_x_n1.Location = new System.Drawing.Point(65, 118);
+            button_x_n1.Name = "button_x_n1";
+            button_x_n1.Size = new System.Drawing.Size(47, 47);
+            button_x_n1.TabIndex = 0;
+            button_x_n1.Text = "-1 Tile";
+            button_x_n1.UseVisualStyleBackColor = true;
+            button_x_n1.Click += button_x_n1_Click;
+            // 
+            // button_x_n2
+            // 
+            button_x_n2.Location = new System.Drawing.Point(12, 118);
+            button_x_n2.Name = "button_x_n2";
+            button_x_n2.Size = new System.Drawing.Size(47, 47);
+            button_x_n2.TabIndex = 1;
+            button_x_n2.Text = "-2 Tile";
+            button_x_n2.UseVisualStyleBackColor = true;
+            button_x_n2.Click += button_x_n2_Click;
+            // 
+            // button_x1
+            // 
+            button_x1.Location = new System.Drawing.Point(171, 118);
+            button_x1.Name = "button_x1";
+            button_x1.Size = new System.Drawing.Size(47, 47);
+            button_x1.TabIndex = 2;
+            button_x1.Text = "1 Tile";
+            button_x1.UseVisualStyleBackColor = true;
+            button_x1.Click += button_x1_Click;
+            // 
+            // button_x2
+            // 
+            button_x2.Location = new System.Drawing.Point(224, 118);
+            button_x2.Name = "button_x2";
+            button_x2.Size = new System.Drawing.Size(47, 47);
+            button_x2.TabIndex = 3;
+            button_x2.Text = "2 Tile";
+            button_x2.UseVisualStyleBackColor = true;
+            button_x2.Click += button_x2_Click;
+            // 
+            // pictureBox1
+            // 
+            pictureBox1.BackgroundImage = Properties.Resources.toolbar_outline_doors;
+            pictureBox1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            pictureBox1.Location = new System.Drawing.Point(118, 118);
+            pictureBox1.Name = "pictureBox1";
+            pictureBox1.Size = new System.Drawing.Size(47, 47);
+            pictureBox1.TabIndex = 4;
+            pictureBox1.TabStop = false;
+            // 
+            // button_y2
+            // 
+            button_y2.Location = new System.Drawing.Point(118, 171);
+            button_y2.Name = "button_y2";
+            button_y2.Size = new System.Drawing.Size(47, 47);
+            button_y2.TabIndex = 8;
+            button_y2.Text = "2 Tile";
+            button_y2.UseVisualStyleBackColor = true;
+            button_y2.Click += button_x2_Click;
+            // 
+            // button_y1
+            // 
+            button_y1.Location = new System.Drawing.Point(118, 224);
+            button_y1.Name = "button_y1";
+            button_y1.Size = new System.Drawing.Size(47, 47);
+            button_y1.TabIndex = 7;
+            button_y1.Text = "1 Tile";
+            button_y1.UseVisualStyleBackColor = true;
+            button_y1.Click += button_x1_Click;
+            // 
+            // button_y_n2
+            // 
+            button_y_n2.Location = new System.Drawing.Point(118, 65);
+            button_y_n2.Name = "button_y_n2";
+            button_y_n2.Size = new System.Drawing.Size(47, 47);
+            button_y_n2.TabIndex = 6;
+            button_y_n2.Text = "-2 Tile";
+            button_y_n2.UseVisualStyleBackColor = true;
+            button_y_n2.Click += button_x_n2_Click;
+            // 
+            // button_y_n1
+            // 
+            button_y_n1.Location = new System.Drawing.Point(118, 12);
+            button_y_n1.Name = "button_y_n1";
+            button_y_n1.Size = new System.Drawing.Size(47, 47);
+            button_y_n1.TabIndex = 5;
+            button_y_n1.Text = "-1 Tile";
+            button_y_n1.UseVisualStyleBackColor = true;
+            button_y_n1.Click += button_x_n1_Click;
+            // 
+            // FormEditDoorPresets
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(284, 284);
+            Controls.Add(button_y2);
+            Controls.Add(button_y1);
+            Controls.Add(button_y_n2);
+            Controls.Add(button_y_n1);
+            Controls.Add(pictureBox1);
+            Controls.Add(button_x2);
+            Controls.Add(button_x1);
+            Controls.Add(button_x_n2);
+            Controls.Add(button_x_n1);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "FormEditDoorPresets";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            Text = "Distance Presets";
+            ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button button_x_n1;
+        private System.Windows.Forms.Button button_x_n2;
+        private System.Windows.Forms.Button button_x1;
+        private System.Windows.Forms.Button button_x2;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Button button_y2;
+        private System.Windows.Forms.Button button_y1;
+        private System.Windows.Forms.Button button_y_n2;
+        private System.Windows.Forms.Button button_y_n1;
+    }
+}

--- a/mage/FormEditDoorPresets.cs
+++ b/mage/FormEditDoorPresets.cs
@@ -1,0 +1,71 @@
+﻿using mage.Theming;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace mage
+{
+    public partial class FormEditDoorPresets : Form
+    {
+        public byte Result { get; set; }
+
+        public FormEditDoorPresets(bool isX)
+        {
+            InitializeComponent();
+
+            ThemeSwitcher.ChangeTheme(this.Controls, this);
+            ThemeSwitcher.InjectPaintOverrides(this.Controls);
+
+            if (isX)
+            {
+                button_y1.Enabled = false;
+                button_y2.Enabled = false;
+                button_y_n1.Enabled = false;
+                button_y_n2.Enabled = false;
+            }
+            else
+            {
+                button_x1.Enabled = false;
+                button_x2.Enabled = false;
+                button_x_n1.Enabled = false;
+                button_x_n2.Enabled = false;
+            }
+        }
+
+        private void button_x1_Click(object sender, EventArgs e)
+        {
+            Result = 0x10;
+            clickedButton();
+        }
+
+        private void button_x2_Click(object sender, EventArgs e)
+        {
+            Result = 0x20;
+            clickedButton();
+        }
+
+        private void button_x_n1_Click(object sender, EventArgs e)
+        {
+            Result = 0xF0;
+            clickedButton();
+        }
+
+        private void button_x_n2_Click(object sender, EventArgs e)
+        {
+            Result = 0xE0;
+            clickedButton();
+        }
+
+        private void clickedButton()
+        {
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+    }
+}

--- a/mage/FormEditDoorPresets.resx
+++ b/mage/FormEditDoorPresets.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/mage/FormMain.Designer.cs
+++ b/mage/FormMain.Designer.cs
@@ -168,6 +168,7 @@
             label_room = new System.Windows.Forms.Label();
             label_area = new System.Windows.Forms.Label();
             groupBox_tileset = new System.Windows.Forms.GroupBox();
+            button_clipdata_shortcuts = new System.Windows.Forms.Button();
             comboBox_clipdata = new Theming.CustomControls.FlatComboBox();
             label_clipdata = new System.Windows.Forms.Label();
             panel_tileset = new System.Windows.Forms.Panel();
@@ -240,6 +241,7 @@
             toolStrip_add = new System.Windows.Forms.ToolStripButton();
             toolStrip_patches = new System.Windows.Forms.ToolStripButton();
             comboBox_spriteset = new Theming.CustomControls.FlatComboBox();
+            ToolTip = new System.Windows.Forms.ToolTip(components);
             menuStrip.SuspendLayout();
             groupBox_location.SuspendLayout();
             groupBox_tileset.SuspendLayout();
@@ -1255,6 +1257,7 @@
             // groupBox_tileset
             // 
             groupBox_tileset.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox_tileset.Controls.Add(button_clipdata_shortcuts);
             groupBox_tileset.Controls.Add(comboBox_clipdata);
             groupBox_tileset.Controls.Add(label_clipdata);
             groupBox_tileset.Controls.Add(panel_tileset);
@@ -1269,14 +1272,26 @@
             groupBox_tileset.TabStop = false;
             groupBox_tileset.Text = "Tileset";
             // 
+            // button_clipdata_shortcuts
+            // 
+            button_clipdata_shortcuts.Image = Properties.Resources.shortcut_shot;
+            button_clipdata_shortcuts.Location = new System.Drawing.Point(303, 22);
+            button_clipdata_shortcuts.Name = "button_clipdata_shortcuts";
+            button_clipdata_shortcuts.Size = new System.Drawing.Size(24, 24);
+            button_clipdata_shortcuts.TabIndex = 12;
+            ToolTip.SetToolTip(button_clipdata_shortcuts, "Clipdata Shortcuts");
+            button_clipdata_shortcuts.UseVisualStyleBackColor = true;
+            button_clipdata_shortcuts.Click += menuItem_clipShortcuts_Click;
+            // 
             // comboBox_clipdata
             // 
             comboBox_clipdata.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_clipdata.DropDownWidth = 228;
             comboBox_clipdata.FormattingEnabled = true;
             comboBox_clipdata.Location = new System.Drawing.Point(68, 22);
             comboBox_clipdata.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             comboBox_clipdata.Name = "comboBox_clipdata";
-            comboBox_clipdata.Size = new System.Drawing.Size(258, 23);
+            comboBox_clipdata.Size = new System.Drawing.Size(228, 23);
             comboBox_clipdata.TabIndex = 11;
             // 
             // label_clipdata
@@ -2236,6 +2251,8 @@
         private Theming.CustomControls.FlatComboBox comboBox_spriteset;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator28;
         private System.Windows.Forms.ToolStripMenuItem themeToolStripMenuItem;
+        private System.Windows.Forms.Button button_clipdata_shortcuts;
+        private System.Windows.Forms.ToolTip ToolTip;
     }
 }
 

--- a/mage/FormMain.Designer.cs
+++ b/mage/FormMain.Designer.cs
@@ -28,2154 +28,2000 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormMain));
-            this.menuStrip = new System.Windows.Forms.MenuStrip();
-            this.menuStrip_file = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_openROM = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_saveROM = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_saveROMas = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_createBackup = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_recentFiles = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_clearRecentFiles = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuStrip_edit = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_editBGs = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_editObjects = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_forceClipdata = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_undo = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_redo = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_editBG0 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_editBG1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_editBG2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_editCLP = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip_view = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewBG0 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewBG1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewBG2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewBG3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewCLP = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewClipCollision = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewClipBreakable = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewClipValues = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_viewSprites = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_outlineSprites = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_outlineDoors = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_outlineScrolls = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator27 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_outlineScreens = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewAnimPal = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_motherShipHatches = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_clipboard = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoom100 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoom200 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoom400 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoom800 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_zoomIn = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_zoomOut = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip_editors = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_headerEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_tilesetEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator24 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_graphicsEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_paletteEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_tileTableEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_animationEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator25 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_spriteEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_spritesetEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_minimapEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_connectionEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_textEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_demoEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_physicsEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_weaponEditor = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip_tools = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_roomOptions = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_testRoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_clipShortcuts = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_import = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importTileset = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importRLE = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importLZ77 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importRoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_importTilesetImage = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importLZ77BGimage = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_importEnding = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_export = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportTileset = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportBG = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportRoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_exportTilesetImage = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportBG0image = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportBG3image = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_exportRoomImage = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_compression = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_LZ77comp = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_LZ77decomp = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_tileBuilder = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_add = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addBG = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addEnemyset = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addRoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addTileset = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addSpriteset = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_addAnim = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_patches = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip_options = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultView = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultBG0 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultBG1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultBG2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultBG3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultClipdata = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultClipCollision = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultClipBreakable = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultClipValues = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_defaultSprites = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultSpriteOutlines = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultDoors = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultScrolls = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_defaultScreens = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_numberBase = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_hexadecimal = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_decimal = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator28 = new System.Windows.Forms.ToolStripSeparator();
-            this.themeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator21 = new System.Windows.Forms.ToolStripSeparator();
-            this.menuItem_tooltips = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip_help = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_viewHelp = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuItem_about = new System.Windows.Forms.ToolStripMenuItem();
-            this.groupBox_location = new System.Windows.Forms.GroupBox();
-            this.comboBox_room = new mage.Theming.CustomControls.FlatComboBox();
-            this.comboBox_area = new mage.Theming.CustomControls.FlatComboBox();
-            this.label_room = new System.Windows.Forms.Label();
-            this.label_area = new System.Windows.Forms.Label();
-            this.groupBox_tileset = new System.Windows.Forms.GroupBox();
-            this.comboBox_clipdata = new mage.Theming.CustomControls.FlatComboBox();
-            this.label_clipdata = new System.Windows.Forms.Label();
-            this.panel_tileset = new System.Windows.Forms.Panel();
-            this.tileView = new mage.TileView();
-            this.groupBox_room = new System.Windows.Forms.GroupBox();
-            this.panel_room = new System.Windows.Forms.Panel();
-            this.roomView = new mage.RoomView();
-            this.contextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.contextItem_addSprite = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_editSprite = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_removeSprite = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
-            this.contextItem_addDoor = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_editDoor = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_removeDoor = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
-            this.contextItem_addScroll = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_editScroll = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextItem_removeScroll = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
-            this.contextItem_testRoom = new System.Windows.Forms.ToolStripMenuItem();
-            this.groupBox_viewBG = new System.Windows.Forms.GroupBox();
-            this.checkBox_viewBG3 = new System.Windows.Forms.CheckBox();
-            this.checkBox_viewBG2 = new System.Windows.Forms.CheckBox();
-            this.checkBox_viewBG1 = new System.Windows.Forms.CheckBox();
-            this.checkBox_viewBG0 = new System.Windows.Forms.CheckBox();
-            this.groupBox_editBG = new System.Windows.Forms.GroupBox();
-            this.checkBox_editCLP = new System.Windows.Forms.CheckBox();
-            this.checkBox_editBG2 = new System.Windows.Forms.CheckBox();
-            this.checkBox_editBG1 = new System.Windows.Forms.CheckBox();
-            this.checkBox_editBG0 = new System.Windows.Forms.CheckBox();
-            this.statusStrip = new System.Windows.Forms.StatusStrip();
-            this.statusLabel_coor = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusLabel_sel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.statusLabel_clip = new System.Windows.Forms.ToolStripStatusLabel();
-            this.label_spriteset = new System.Windows.Forms.Label();
-            this.toolStrip = new System.Windows.Forms.ToolStrip();
-            this.toolStrip_open = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_save = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStrip_undo = new System.Windows.Forms.ToolStripSplitButton();
-            this.toolStrip_redo = new System.Windows.Forms.ToolStripSplitButton();
-            this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStrip_editBGs = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_editObjects = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStrip_viewSprites = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_outlineSprites = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_outlineDoors = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_outlineScrolls = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStrip_header = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_tileset = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_graphics = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_palette = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_tileTable = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_animation = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_sprite = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_spriteset = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_connection = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_minimap = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_text = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_demoEditor = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_physics = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_weapon = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStrip_options = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_test = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_tileBuilder = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_add = new System.Windows.Forms.ToolStripButton();
-            this.toolStrip_patches = new System.Windows.Forms.ToolStripButton();
-            this.comboBox_spriteset = new mage.Theming.CustomControls.FlatComboBox();
-            this.menuStrip.SuspendLayout();
-            this.groupBox_location.SuspendLayout();
-            this.groupBox_tileset.SuspendLayout();
-            this.panel_tileset.SuspendLayout();
-            this.groupBox_room.SuspendLayout();
-            this.panel_room.SuspendLayout();
-            this.contextMenu.SuspendLayout();
-            this.groupBox_viewBG.SuspendLayout();
-            this.groupBox_editBG.SuspendLayout();
-            this.statusStrip.SuspendLayout();
-            this.toolStrip.SuspendLayout();
-            this.SuspendLayout();
+            menuStrip = new System.Windows.Forms.MenuStrip();
+            menuStrip_file = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_openROM = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_saveROM = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_saveROMas = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_createBackup = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_recentFiles = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_clearRecentFiles = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator22 = new System.Windows.Forms.ToolStripSeparator();
+            menuStrip_edit = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_editBGs = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_editObjects = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator17 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_forceClipdata = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator19 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_undo = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_redo = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_editBG0 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_editBG1 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_editBG2 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_editCLP = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip_view = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewBG0 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewBG1 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewBG2 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewBG3 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewCLP = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewClipCollision = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewClipBreakable = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewClipValues = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_viewSprites = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_outlineSprites = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_outlineDoors = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_outlineScrolls = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator27 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_outlineScreens = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewAnimPal = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_motherShipHatches = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator18 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_clipboard = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoom = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoom100 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoom200 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoom400 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoom800 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator20 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_zoomIn = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_zoomOut = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip_editors = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_headerEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_tilesetEditor = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator24 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_graphicsEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_paletteEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_tileTableEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_animationEditor = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator25 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_spriteEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_spritesetEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_minimapEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_connectionEditor = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator26 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_textEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_demoEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_physicsEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_weaponEditor = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip_tools = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_roomOptions = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_testRoom = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_clipShortcuts = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_import = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importTileset = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importRLE = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importLZ77 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importRoom = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_importTilesetImage = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importLZ77BGimage = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_importEnding = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_export = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportTileset = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportBG = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportRoom = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_exportTilesetImage = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportBG0image = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportBG3image = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_exportRoomImage = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_compression = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_LZ77comp = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_LZ77decomp = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator23 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_tileBuilder = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_add = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addBG = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addEnemyset = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addRoom = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addTileset = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addSpriteset = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_addAnim = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_patches = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip_options = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultView = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultBG0 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultBG1 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultBG2 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultBG3 = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultClipdata = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultClipCollision = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultClipBreakable = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultClipValues = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_defaultSprites = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultSpriteOutlines = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultDoors = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultScrolls = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_defaultScreens = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_numberBase = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_hexadecimal = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_decimal = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator28 = new System.Windows.Forms.ToolStripSeparator();
+            themeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator21 = new System.Windows.Forms.ToolStripSeparator();
+            menuItem_tooltips = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip_help = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_viewHelp = new System.Windows.Forms.ToolStripMenuItem();
+            menuItem_about = new System.Windows.Forms.ToolStripMenuItem();
+            groupBox_location = new System.Windows.Forms.GroupBox();
+            comboBox_room = new Theming.CustomControls.FlatComboBox();
+            comboBox_area = new Theming.CustomControls.FlatComboBox();
+            label_room = new System.Windows.Forms.Label();
+            label_area = new System.Windows.Forms.Label();
+            groupBox_tileset = new System.Windows.Forms.GroupBox();
+            comboBox_clipdata = new Theming.CustomControls.FlatComboBox();
+            label_clipdata = new System.Windows.Forms.Label();
+            panel_tileset = new System.Windows.Forms.Panel();
+            tileView = new TileView();
+            groupBox_room = new System.Windows.Forms.GroupBox();
+            panel_room = new System.Windows.Forms.Panel();
+            roomView = new RoomView();
+            contextMenu = new System.Windows.Forms.ContextMenuStrip(components);
+            contextItem_addSprite = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_editSprite = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_removeSprite = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
+            contextItem_addDoor = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_editDoor = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_removeDoor = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator12 = new System.Windows.Forms.ToolStripSeparator();
+            contextItem_addScroll = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_editScroll = new System.Windows.Forms.ToolStripMenuItem();
+            contextItem_removeScroll = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator14 = new System.Windows.Forms.ToolStripSeparator();
+            contextItem_testRoom = new System.Windows.Forms.ToolStripMenuItem();
+            groupBox_viewBG = new System.Windows.Forms.GroupBox();
+            checkBox_viewBG3 = new System.Windows.Forms.CheckBox();
+            checkBox_viewBG2 = new System.Windows.Forms.CheckBox();
+            checkBox_viewBG1 = new System.Windows.Forms.CheckBox();
+            checkBox_viewBG0 = new System.Windows.Forms.CheckBox();
+            groupBox_editBG = new System.Windows.Forms.GroupBox();
+            checkBox_editCLP = new System.Windows.Forms.CheckBox();
+            checkBox_editBG2 = new System.Windows.Forms.CheckBox();
+            checkBox_editBG1 = new System.Windows.Forms.CheckBox();
+            checkBox_editBG0 = new System.Windows.Forms.CheckBox();
+            statusStrip = new System.Windows.Forms.StatusStrip();
+            statusLabel_coor = new System.Windows.Forms.ToolStripStatusLabel();
+            statusLabel_sel = new System.Windows.Forms.ToolStripStatusLabel();
+            statusLabel_clip = new System.Windows.Forms.ToolStripStatusLabel();
+            label_spriteset = new System.Windows.Forms.Label();
+            toolStrip = new System.Windows.Forms.ToolStrip();
+            toolStrip_open = new System.Windows.Forms.ToolStripButton();
+            toolStrip_save = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+            toolStrip_undo = new System.Windows.Forms.ToolStripSplitButton();
+            toolStrip_redo = new System.Windows.Forms.ToolStripSplitButton();
+            toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+            toolStrip_editBGs = new System.Windows.Forms.ToolStripButton();
+            toolStrip_editObjects = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator15 = new System.Windows.Forms.ToolStripSeparator();
+            toolStrip_viewSprites = new System.Windows.Forms.ToolStripButton();
+            toolStrip_outlineSprites = new System.Windows.Forms.ToolStripButton();
+            toolStrip_outlineDoors = new System.Windows.Forms.ToolStripButton();
+            toolStrip_outlineScrolls = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator16 = new System.Windows.Forms.ToolStripSeparator();
+            toolStrip_header = new System.Windows.Forms.ToolStripButton();
+            toolStrip_tileset = new System.Windows.Forms.ToolStripButton();
+            toolStrip_graphics = new System.Windows.Forms.ToolStripButton();
+            toolStrip_palette = new System.Windows.Forms.ToolStripButton();
+            toolStrip_tileTable = new System.Windows.Forms.ToolStripButton();
+            toolStrip_animation = new System.Windows.Forms.ToolStripButton();
+            toolStrip_sprite = new System.Windows.Forms.ToolStripButton();
+            toolStrip_spriteset = new System.Windows.Forms.ToolStripButton();
+            toolStrip_connection = new System.Windows.Forms.ToolStripButton();
+            toolStrip_minimap = new System.Windows.Forms.ToolStripButton();
+            toolStrip_text = new System.Windows.Forms.ToolStripButton();
+            toolStrip_demoEditor = new System.Windows.Forms.ToolStripButton();
+            toolStrip_physics = new System.Windows.Forms.ToolStripButton();
+            toolStrip_weapon = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+            toolStrip_options = new System.Windows.Forms.ToolStripButton();
+            toolStrip_test = new System.Windows.Forms.ToolStripButton();
+            toolStrip_tileBuilder = new System.Windows.Forms.ToolStripButton();
+            toolStrip_add = new System.Windows.Forms.ToolStripButton();
+            toolStrip_patches = new System.Windows.Forms.ToolStripButton();
+            comboBox_spriteset = new Theming.CustomControls.FlatComboBox();
+            menuStrip.SuspendLayout();
+            groupBox_location.SuspendLayout();
+            groupBox_tileset.SuspendLayout();
+            panel_tileset.SuspendLayout();
+            groupBox_room.SuspendLayout();
+            panel_room.SuspendLayout();
+            contextMenu.SuspendLayout();
+            groupBox_viewBG.SuspendLayout();
+            groupBox_editBG.SuspendLayout();
+            statusStrip.SuspendLayout();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
             // 
             // menuStrip
             // 
-            this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuStrip_file,
-            this.menuStrip_edit,
-            this.menuStrip_view,
-            this.menuStrip_editors,
-            this.menuStrip_tools,
-            this.menuStrip_options,
-            this.menuStrip_help});
-            this.menuStrip.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip.Name = "menuStrip";
-            this.menuStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuStrip.Size = new System.Drawing.Size(796, 24);
-            this.menuStrip.TabIndex = 0;
+            menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { menuStrip_file, menuStrip_edit, menuStrip_view, menuStrip_editors, menuStrip_tools, menuStrip_options, menuStrip_help });
+            menuStrip.Location = new System.Drawing.Point(0, 0);
+            menuStrip.Name = "menuStrip";
+            menuStrip.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            menuStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            menuStrip.Size = new System.Drawing.Size(929, 24);
+            menuStrip.TabIndex = 0;
             // 
             // menuStrip_file
             // 
-            this.menuStrip_file.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_openROM,
-            this.menuItem_saveROM,
-            this.menuItem_saveROMas,
-            this.toolStripSeparator5,
-            this.menuItem_createBackup,
-            this.toolStripSeparator3,
-            this.menuItem_recentFiles});
-            this.menuStrip_file.Name = "menuStrip_file";
-            this.menuStrip_file.Size = new System.Drawing.Size(37, 20);
-            this.menuStrip_file.Text = "File";
+            menuStrip_file.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_openROM, menuItem_saveROM, menuItem_saveROMas, toolStripSeparator5, menuItem_createBackup, toolStripSeparator3, menuItem_recentFiles });
+            menuStrip_file.Name = "menuStrip_file";
+            menuStrip_file.Size = new System.Drawing.Size(37, 20);
+            menuStrip_file.Text = "File";
             // 
             // menuItem_openROM
             // 
-            this.menuItem_openROM.Name = "menuItem_openROM";
-            this.menuItem_openROM.Size = new System.Drawing.Size(151, 22);
-            this.menuItem_openROM.Text = "Open ROM...";
-            this.menuItem_openROM.Click += new System.EventHandler(this.menuItem_openROM_Click);
+            menuItem_openROM.Name = "menuItem_openROM";
+            menuItem_openROM.Size = new System.Drawing.Size(151, 22);
+            menuItem_openROM.Text = "Open ROM...";
+            menuItem_openROM.Click += menuItem_openROM_Click;
             // 
             // menuItem_saveROM
             // 
-            this.menuItem_saveROM.Enabled = false;
-            this.menuItem_saveROM.Name = "menuItem_saveROM";
-            this.menuItem_saveROM.Size = new System.Drawing.Size(151, 22);
-            this.menuItem_saveROM.Text = "Save ROM";
-            this.menuItem_saveROM.Click += new System.EventHandler(this.menuItem_saveROM_Click);
+            menuItem_saveROM.Enabled = false;
+            menuItem_saveROM.Name = "menuItem_saveROM";
+            menuItem_saveROM.Size = new System.Drawing.Size(151, 22);
+            menuItem_saveROM.Text = "Save ROM";
+            menuItem_saveROM.Click += menuItem_saveROM_Click;
             // 
             // menuItem_saveROMas
             // 
-            this.menuItem_saveROMas.Enabled = false;
-            this.menuItem_saveROMas.Name = "menuItem_saveROMas";
-            this.menuItem_saveROMas.Size = new System.Drawing.Size(151, 22);
-            this.menuItem_saveROMas.Text = "Save ROM as...";
-            this.menuItem_saveROMas.Click += new System.EventHandler(this.menuItem_saveROMAs_Click);
+            menuItem_saveROMas.Enabled = false;
+            menuItem_saveROMas.Name = "menuItem_saveROMas";
+            menuItem_saveROMas.Size = new System.Drawing.Size(151, 22);
+            menuItem_saveROMas.Text = "Save ROM as...";
+            menuItem_saveROMas.Click += menuItem_saveROMAs_Click;
             // 
             // toolStripSeparator5
             // 
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(148, 6);
+            toolStripSeparator5.Name = "toolStripSeparator5";
+            toolStripSeparator5.Size = new System.Drawing.Size(148, 6);
             // 
             // menuItem_createBackup
             // 
-            this.menuItem_createBackup.Enabled = false;
-            this.menuItem_createBackup.Name = "menuItem_createBackup";
-            this.menuItem_createBackup.Size = new System.Drawing.Size(151, 22);
-            this.menuItem_createBackup.Text = "Create Backup";
-            this.menuItem_createBackup.Click += new System.EventHandler(this.menuItem_createBackup_Click);
+            menuItem_createBackup.Enabled = false;
+            menuItem_createBackup.Name = "menuItem_createBackup";
+            menuItem_createBackup.Size = new System.Drawing.Size(151, 22);
+            menuItem_createBackup.Text = "Create Backup";
+            menuItem_createBackup.Click += menuItem_createBackup_Click;
             // 
             // toolStripSeparator3
             // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(148, 6);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new System.Drawing.Size(148, 6);
             // 
             // menuItem_recentFiles
             // 
-            this.menuItem_recentFiles.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_clearRecentFiles,
-            this.toolStripSeparator22});
-            this.menuItem_recentFiles.Name = "menuItem_recentFiles";
-            this.menuItem_recentFiles.Size = new System.Drawing.Size(151, 22);
-            this.menuItem_recentFiles.Text = "Recent Files";
+            menuItem_recentFiles.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_clearRecentFiles, toolStripSeparator22 });
+            menuItem_recentFiles.Name = "menuItem_recentFiles";
+            menuItem_recentFiles.Size = new System.Drawing.Size(151, 22);
+            menuItem_recentFiles.Text = "Recent Files";
             // 
             // menuItem_clearRecentFiles
             // 
-            this.menuItem_clearRecentFiles.Name = "menuItem_clearRecentFiles";
-            this.menuItem_clearRecentFiles.Size = new System.Drawing.Size(101, 22);
-            this.menuItem_clearRecentFiles.Text = "Clear";
-            this.menuItem_clearRecentFiles.Click += new System.EventHandler(this.menuItem_clearRecentFiles_Click);
+            menuItem_clearRecentFiles.Name = "menuItem_clearRecentFiles";
+            menuItem_clearRecentFiles.Size = new System.Drawing.Size(101, 22);
+            menuItem_clearRecentFiles.Text = "Clear";
+            menuItem_clearRecentFiles.Click += menuItem_clearRecentFiles_Click;
             // 
             // toolStripSeparator22
             // 
-            this.toolStripSeparator22.Name = "toolStripSeparator22";
-            this.toolStripSeparator22.Size = new System.Drawing.Size(98, 6);
+            toolStripSeparator22.Name = "toolStripSeparator22";
+            toolStripSeparator22.Size = new System.Drawing.Size(98, 6);
             // 
             // menuStrip_edit
             // 
-            this.menuStrip_edit.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_editBGs,
-            this.menuItem_editObjects,
-            this.toolStripSeparator17,
-            this.menuItem_forceClipdata,
-            this.toolStripSeparator19,
-            this.menuItem_undo,
-            this.menuItem_redo,
-            this.toolStripSeparator4,
-            this.menuItem_editBG0,
-            this.menuItem_editBG1,
-            this.menuItem_editBG2,
-            this.menuItem_editCLP});
-            this.menuStrip_edit.Enabled = false;
-            this.menuStrip_edit.Name = "menuStrip_edit";
-            this.menuStrip_edit.Size = new System.Drawing.Size(39, 20);
-            this.menuStrip_edit.Text = "Edit";
+            menuStrip_edit.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_editBGs, menuItem_editObjects, toolStripSeparator17, menuItem_forceClipdata, toolStripSeparator19, menuItem_undo, menuItem_redo, toolStripSeparator4, menuItem_editBG0, menuItem_editBG1, menuItem_editBG2, menuItem_editCLP });
+            menuStrip_edit.Enabled = false;
+            menuStrip_edit.Name = "menuStrip_edit";
+            menuStrip_edit.Size = new System.Drawing.Size(39, 20);
+            menuStrip_edit.Text = "Edit";
             // 
             // menuItem_editBGs
             // 
-            this.menuItem_editBGs.Name = "menuItem_editBGs";
-            this.menuItem_editBGs.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editBGs.Text = "BG Editing Mode";
-            this.menuItem_editBGs.Click += new System.EventHandler(this.menuItem_editMode_Click);
+            menuItem_editBGs.Name = "menuItem_editBGs";
+            menuItem_editBGs.Size = new System.Drawing.Size(187, 22);
+            menuItem_editBGs.Text = "BG Editing Mode";
+            menuItem_editBGs.Click += menuItem_editMode_Click;
             // 
             // menuItem_editObjects
             // 
-            this.menuItem_editObjects.Name = "menuItem_editObjects";
-            this.menuItem_editObjects.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editObjects.Text = "Object Editing Mode";
-            this.menuItem_editObjects.Click += new System.EventHandler(this.menuItem_editMode_Click);
+            menuItem_editObjects.Name = "menuItem_editObjects";
+            menuItem_editObjects.Size = new System.Drawing.Size(187, 22);
+            menuItem_editObjects.Text = "Object Editing Mode";
+            menuItem_editObjects.Click += menuItem_editMode_Click;
             // 
             // toolStripSeparator17
             // 
-            this.toolStripSeparator17.Name = "toolStripSeparator17";
-            this.toolStripSeparator17.Size = new System.Drawing.Size(184, 6);
+            toolStripSeparator17.Name = "toolStripSeparator17";
+            toolStripSeparator17.Size = new System.Drawing.Size(184, 6);
             // 
             // menuItem_forceClipdata
             // 
-            this.menuItem_forceClipdata.Name = "menuItem_forceClipdata";
-            this.menuItem_forceClipdata.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_forceClipdata.Text = "Use Selected Clipdata";
-            this.menuItem_forceClipdata.Click += new System.EventHandler(this.menuItem_forceClipdata_Click);
+            menuItem_forceClipdata.Name = "menuItem_forceClipdata";
+            menuItem_forceClipdata.Size = new System.Drawing.Size(187, 22);
+            menuItem_forceClipdata.Text = "Use Selected Clipdata";
+            menuItem_forceClipdata.Click += menuItem_forceClipdata_Click;
             // 
             // toolStripSeparator19
             // 
-            this.toolStripSeparator19.Name = "toolStripSeparator19";
-            this.toolStripSeparator19.Size = new System.Drawing.Size(184, 6);
+            toolStripSeparator19.Name = "toolStripSeparator19";
+            toolStripSeparator19.Size = new System.Drawing.Size(184, 6);
             // 
             // menuItem_undo
             // 
-            this.menuItem_undo.Enabled = false;
-            this.menuItem_undo.Name = "menuItem_undo";
-            this.menuItem_undo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.menuItem_undo.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_undo.Text = "Undo";
-            this.menuItem_undo.Click += new System.EventHandler(this.menuItem_undo_Click);
+            menuItem_undo.Enabled = false;
+            menuItem_undo.Name = "menuItem_undo";
+            menuItem_undo.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z;
+            menuItem_undo.Size = new System.Drawing.Size(187, 22);
+            menuItem_undo.Text = "Undo";
+            menuItem_undo.Click += menuItem_undo_Click;
             // 
             // menuItem_redo
             // 
-            this.menuItem_redo.Enabled = false;
-            this.menuItem_redo.Name = "menuItem_redo";
-            this.menuItem_redo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-            this.menuItem_redo.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_redo.Text = "Redo";
-            this.menuItem_redo.Click += new System.EventHandler(this.menuItem_redo_Click);
+            menuItem_redo.Enabled = false;
+            menuItem_redo.Name = "menuItem_redo";
+            menuItem_redo.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y;
+            menuItem_redo.Size = new System.Drawing.Size(187, 22);
+            menuItem_redo.Text = "Redo";
+            menuItem_redo.Click += menuItem_redo_Click;
             // 
             // toolStripSeparator4
             // 
-            this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(184, 6);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new System.Drawing.Size(184, 6);
             // 
             // menuItem_editBG0
             // 
-            this.menuItem_editBG0.Name = "menuItem_editBG0";
-            this.menuItem_editBG0.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D1)));
-            this.menuItem_editBG0.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editBG0.Text = "BG 0";
-            this.menuItem_editBG0.Click += new System.EventHandler(this.menuItem_editBG0_Click);
+            menuItem_editBG0.Name = "menuItem_editBG0";
+            menuItem_editBG0.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D1;
+            menuItem_editBG0.Size = new System.Drawing.Size(187, 22);
+            menuItem_editBG0.Text = "BG 0";
+            menuItem_editBG0.Click += menuItem_editBG0_Click;
             // 
             // menuItem_editBG1
             // 
-            this.menuItem_editBG1.Name = "menuItem_editBG1";
-            this.menuItem_editBG1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D2)));
-            this.menuItem_editBG1.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editBG1.Text = "BG 1";
-            this.menuItem_editBG1.Click += new System.EventHandler(this.menuItem_editBG1_Click);
+            menuItem_editBG1.Name = "menuItem_editBG1";
+            menuItem_editBG1.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D2;
+            menuItem_editBG1.Size = new System.Drawing.Size(187, 22);
+            menuItem_editBG1.Text = "BG 1";
+            menuItem_editBG1.Click += menuItem_editBG1_Click;
             // 
             // menuItem_editBG2
             // 
-            this.menuItem_editBG2.Name = "menuItem_editBG2";
-            this.menuItem_editBG2.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D3)));
-            this.menuItem_editBG2.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editBG2.Text = "BG 2";
-            this.menuItem_editBG2.Click += new System.EventHandler(this.menuItem_editBG2_Click);
+            menuItem_editBG2.Name = "menuItem_editBG2";
+            menuItem_editBG2.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D3;
+            menuItem_editBG2.Size = new System.Drawing.Size(187, 22);
+            menuItem_editBG2.Text = "BG 2";
+            menuItem_editBG2.Click += menuItem_editBG2_Click;
             // 
             // menuItem_editCLP
             // 
-            this.menuItem_editCLP.Name = "menuItem_editCLP";
-            this.menuItem_editCLP.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D4)));
-            this.menuItem_editCLP.Size = new System.Drawing.Size(187, 22);
-            this.menuItem_editCLP.Text = "Clipdata";
-            this.menuItem_editCLP.Click += new System.EventHandler(this.menuItem_editCLP_Click);
+            menuItem_editCLP.Name = "menuItem_editCLP";
+            menuItem_editCLP.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.D4;
+            menuItem_editCLP.Size = new System.Drawing.Size(187, 22);
+            menuItem_editCLP.Text = "Clipdata";
+            menuItem_editCLP.Click += menuItem_editCLP_Click;
             // 
             // menuStrip_view
             // 
-            this.menuStrip_view.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_viewBG0,
-            this.menuItem_viewBG1,
-            this.menuItem_viewBG2,
-            this.menuItem_viewBG3,
-            this.menuItem_viewCLP,
-            this.toolStripSeparator1,
-            this.menuItem_viewSprites,
-            this.menuItem_outlineSprites,
-            this.menuItem_outlineDoors,
-            this.menuItem_outlineScrolls,
-            this.toolStripSeparator27,
-            this.menuItem_outlineScreens,
-            this.menuItem_viewAnimPal,
-            this.menuItem_motherShipHatches,
-            this.toolStripSeparator18,
-            this.menuItem_clipboard,
-            this.menuItem_zoom});
-            this.menuStrip_view.Enabled = false;
-            this.menuStrip_view.Name = "menuStrip_view";
-            this.menuStrip_view.Size = new System.Drawing.Size(44, 20);
-            this.menuStrip_view.Text = "View";
+            menuStrip_view.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_viewBG0, menuItem_viewBG1, menuItem_viewBG2, menuItem_viewBG3, menuItem_viewCLP, toolStripSeparator1, menuItem_viewSprites, menuItem_outlineSprites, menuItem_outlineDoors, menuItem_outlineScrolls, toolStripSeparator27, menuItem_outlineScreens, menuItem_viewAnimPal, menuItem_motherShipHatches, toolStripSeparator18, menuItem_clipboard, menuItem_zoom });
+            menuStrip_view.Enabled = false;
+            menuStrip_view.Name = "menuStrip_view";
+            menuStrip_view.Size = new System.Drawing.Size(44, 20);
+            menuStrip_view.Text = "View";
             // 
             // menuItem_viewBG0
             // 
-            this.menuItem_viewBG0.Name = "menuItem_viewBG0";
-            this.menuItem_viewBG0.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D1)));
-            this.menuItem_viewBG0.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewBG0.Text = "BG 0";
-            this.menuItem_viewBG0.Click += new System.EventHandler(this.menuItem_viewBG0_Click);
+            menuItem_viewBG0.Name = "menuItem_viewBG0";
+            menuItem_viewBG0.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D1;
+            menuItem_viewBG0.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewBG0.Text = "BG 0";
+            menuItem_viewBG0.Click += menuItem_viewBG0_Click;
             // 
             // menuItem_viewBG1
             // 
-            this.menuItem_viewBG1.Name = "menuItem_viewBG1";
-            this.menuItem_viewBG1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D2)));
-            this.menuItem_viewBG1.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewBG1.Text = "BG 1";
-            this.menuItem_viewBG1.Click += new System.EventHandler(this.menuItem_viewBG1_Click);
+            menuItem_viewBG1.Name = "menuItem_viewBG1";
+            menuItem_viewBG1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D2;
+            menuItem_viewBG1.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewBG1.Text = "BG 1";
+            menuItem_viewBG1.Click += menuItem_viewBG1_Click;
             // 
             // menuItem_viewBG2
             // 
-            this.menuItem_viewBG2.Name = "menuItem_viewBG2";
-            this.menuItem_viewBG2.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D3)));
-            this.menuItem_viewBG2.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewBG2.Text = "BG 2";
-            this.menuItem_viewBG2.Click += new System.EventHandler(this.menuItem_viewBG2_Click);
+            menuItem_viewBG2.Name = "menuItem_viewBG2";
+            menuItem_viewBG2.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D3;
+            menuItem_viewBG2.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewBG2.Text = "BG 2";
+            menuItem_viewBG2.Click += menuItem_viewBG2_Click;
             // 
             // menuItem_viewBG3
             // 
-            this.menuItem_viewBG3.Name = "menuItem_viewBG3";
-            this.menuItem_viewBG3.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D4)));
-            this.menuItem_viewBG3.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewBG3.Text = "BG 3";
-            this.menuItem_viewBG3.Click += new System.EventHandler(this.menuItem_viewBG3_Click);
+            menuItem_viewBG3.Name = "menuItem_viewBG3";
+            menuItem_viewBG3.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D4;
+            menuItem_viewBG3.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewBG3.Text = "BG 3";
+            menuItem_viewBG3.Click += menuItem_viewBG3_Click;
             // 
             // menuItem_viewCLP
             // 
-            this.menuItem_viewCLP.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_viewClipCollision,
-            this.menuItem_viewClipBreakable,
-            this.menuItem_viewClipValues});
-            this.menuItem_viewCLP.Name = "menuItem_viewCLP";
-            this.menuItem_viewCLP.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewCLP.Text = "Clipdata";
+            menuItem_viewCLP.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_viewClipCollision, menuItem_viewClipBreakable, menuItem_viewClipValues });
+            menuItem_viewCLP.Name = "menuItem_viewCLP";
+            menuItem_viewCLP.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewCLP.Text = "Clipdata";
             // 
             // menuItem_viewClipCollision
             // 
-            this.menuItem_viewClipCollision.Name = "menuItem_viewClipCollision";
-            this.menuItem_viewClipCollision.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D5)));
-            this.menuItem_viewClipCollision.Size = new System.Drawing.Size(165, 22);
-            this.menuItem_viewClipCollision.Text = "Collision";
-            this.menuItem_viewClipCollision.Click += new System.EventHandler(this.menuItem_viewClipToggle_Click);
+            menuItem_viewClipCollision.Name = "menuItem_viewClipCollision";
+            menuItem_viewClipCollision.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D5;
+            menuItem_viewClipCollision.Size = new System.Drawing.Size(165, 22);
+            menuItem_viewClipCollision.Text = "Collision";
+            menuItem_viewClipCollision.Click += menuItem_viewClipToggle_Click;
             // 
             // menuItem_viewClipBreakable
             // 
-            this.menuItem_viewClipBreakable.Name = "menuItem_viewClipBreakable";
-            this.menuItem_viewClipBreakable.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D6)));
-            this.menuItem_viewClipBreakable.Size = new System.Drawing.Size(165, 22);
-            this.menuItem_viewClipBreakable.Text = "Breakable";
-            this.menuItem_viewClipBreakable.Click += new System.EventHandler(this.menuItem_viewClipToggle_Click);
+            menuItem_viewClipBreakable.Name = "menuItem_viewClipBreakable";
+            menuItem_viewClipBreakable.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D6;
+            menuItem_viewClipBreakable.Size = new System.Drawing.Size(165, 22);
+            menuItem_viewClipBreakable.Text = "Breakable";
+            menuItem_viewClipBreakable.Click += menuItem_viewClipToggle_Click;
             // 
             // menuItem_viewClipValues
             // 
-            this.menuItem_viewClipValues.Name = "menuItem_viewClipValues";
-            this.menuItem_viewClipValues.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D7)));
-            this.menuItem_viewClipValues.Size = new System.Drawing.Size(165, 22);
-            this.menuItem_viewClipValues.Text = "Values";
-            this.menuItem_viewClipValues.Click += new System.EventHandler(this.menuItem_viewClipToggle_Click);
+            menuItem_viewClipValues.Name = "menuItem_viewClipValues";
+            menuItem_viewClipValues.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D7;
+            menuItem_viewClipValues.Size = new System.Drawing.Size(165, 22);
+            menuItem_viewClipValues.Text = "Values";
+            menuItem_viewClipValues.Click += menuItem_viewClipToggle_Click;
             // 
             // toolStripSeparator1
             // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(201, 6);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(201, 6);
             // 
             // menuItem_viewSprites
             // 
-            this.menuItem_viewSprites.Name = "menuItem_viewSprites";
-            this.menuItem_viewSprites.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.menuItem_viewSprites.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewSprites.Text = "Sprites";
-            this.menuItem_viewSprites.Click += new System.EventHandler(this.menuItem_viewSprites_Click);
+            menuItem_viewSprites.Name = "menuItem_viewSprites";
+            menuItem_viewSprites.ShortcutKeys = System.Windows.Forms.Keys.F1;
+            menuItem_viewSprites.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewSprites.Text = "Sprites";
+            menuItem_viewSprites.Click += menuItem_viewSprites_Click;
             // 
             // menuItem_outlineSprites
             // 
-            this.menuItem_outlineSprites.Name = "menuItem_outlineSprites";
-            this.menuItem_outlineSprites.ShortcutKeys = System.Windows.Forms.Keys.F2;
-            this.menuItem_outlineSprites.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_outlineSprites.Text = "Sprite Outlines";
-            this.menuItem_outlineSprites.Click += new System.EventHandler(this.menuItem_outlineSprites_Click);
+            menuItem_outlineSprites.Name = "menuItem_outlineSprites";
+            menuItem_outlineSprites.ShortcutKeys = System.Windows.Forms.Keys.F2;
+            menuItem_outlineSprites.Size = new System.Drawing.Size(204, 22);
+            menuItem_outlineSprites.Text = "Sprite Outlines";
+            menuItem_outlineSprites.Click += menuItem_outlineSprites_Click;
             // 
             // menuItem_outlineDoors
             // 
-            this.menuItem_outlineDoors.Name = "menuItem_outlineDoors";
-            this.menuItem_outlineDoors.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.menuItem_outlineDoors.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_outlineDoors.Text = "Doors";
-            this.menuItem_outlineDoors.Click += new System.EventHandler(this.menuItem_outlineDoors_Click);
+            menuItem_outlineDoors.Name = "menuItem_outlineDoors";
+            menuItem_outlineDoors.ShortcutKeys = System.Windows.Forms.Keys.F3;
+            menuItem_outlineDoors.Size = new System.Drawing.Size(204, 22);
+            menuItem_outlineDoors.Text = "Doors";
+            menuItem_outlineDoors.Click += menuItem_outlineDoors_Click;
             // 
             // menuItem_outlineScrolls
             // 
-            this.menuItem_outlineScrolls.Name = "menuItem_outlineScrolls";
-            this.menuItem_outlineScrolls.ShortcutKeys = System.Windows.Forms.Keys.F4;
-            this.menuItem_outlineScrolls.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_outlineScrolls.Text = "Scrolls";
-            this.menuItem_outlineScrolls.Click += new System.EventHandler(this.menuItem_outlineScrolls_Click);
+            menuItem_outlineScrolls.Name = "menuItem_outlineScrolls";
+            menuItem_outlineScrolls.ShortcutKeys = System.Windows.Forms.Keys.F4;
+            menuItem_outlineScrolls.Size = new System.Drawing.Size(204, 22);
+            menuItem_outlineScrolls.Text = "Scrolls";
+            menuItem_outlineScrolls.Click += menuItem_outlineScrolls_Click;
             // 
             // toolStripSeparator27
             // 
-            this.toolStripSeparator27.Name = "toolStripSeparator27";
-            this.toolStripSeparator27.Size = new System.Drawing.Size(201, 6);
+            toolStripSeparator27.Name = "toolStripSeparator27";
+            toolStripSeparator27.Size = new System.Drawing.Size(201, 6);
             // 
             // menuItem_outlineScreens
             // 
-            this.menuItem_outlineScreens.Name = "menuItem_outlineScreens";
-            this.menuItem_outlineScreens.ShortcutKeys = System.Windows.Forms.Keys.F5;
-            this.menuItem_outlineScreens.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_outlineScreens.Text = "Screen Outlines";
-            this.menuItem_outlineScreens.Click += new System.EventHandler(this.menuItem_outlineScreens_Click);
+            menuItem_outlineScreens.Name = "menuItem_outlineScreens";
+            menuItem_outlineScreens.ShortcutKeys = System.Windows.Forms.Keys.F5;
+            menuItem_outlineScreens.Size = new System.Drawing.Size(204, 22);
+            menuItem_outlineScreens.Text = "Screen Outlines";
+            menuItem_outlineScreens.Click += menuItem_outlineScreens_Click;
             // 
             // menuItem_viewAnimPal
             // 
-            this.menuItem_viewAnimPal.Name = "menuItem_viewAnimPal";
-            this.menuItem_viewAnimPal.ShortcutKeys = System.Windows.Forms.Keys.F6;
-            this.menuItem_viewAnimPal.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_viewAnimPal.Text = "Animated Palette";
-            this.menuItem_viewAnimPal.Click += new System.EventHandler(this.menuItem_viewAnimPal_Click);
+            menuItem_viewAnimPal.Name = "menuItem_viewAnimPal";
+            menuItem_viewAnimPal.ShortcutKeys = System.Windows.Forms.Keys.F6;
+            menuItem_viewAnimPal.Size = new System.Drawing.Size(204, 22);
+            menuItem_viewAnimPal.Text = "Animated Palette";
+            menuItem_viewAnimPal.Click += menuItem_viewAnimPal_Click;
             // 
             // menuItem_motherShipHatches
             // 
-            this.menuItem_motherShipHatches.Name = "menuItem_motherShipHatches";
-            this.menuItem_motherShipHatches.ShortcutKeys = System.Windows.Forms.Keys.F7;
-            this.menuItem_motherShipHatches.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_motherShipHatches.Text = "Mother Ship Hatches";
-            this.menuItem_motherShipHatches.Click += new System.EventHandler(this.menuItem_motherShipHatches_Click);
+            menuItem_motherShipHatches.Name = "menuItem_motherShipHatches";
+            menuItem_motherShipHatches.ShortcutKeys = System.Windows.Forms.Keys.F7;
+            menuItem_motherShipHatches.Size = new System.Drawing.Size(204, 22);
+            menuItem_motherShipHatches.Text = "Mother Ship Hatches";
+            menuItem_motherShipHatches.Click += menuItem_motherShipHatches_Click;
             // 
             // toolStripSeparator18
             // 
-            this.toolStripSeparator18.Name = "toolStripSeparator18";
-            this.toolStripSeparator18.Size = new System.Drawing.Size(201, 6);
+            toolStripSeparator18.Name = "toolStripSeparator18";
+            toolStripSeparator18.Size = new System.Drawing.Size(201, 6);
             // 
             // menuItem_clipboard
             // 
-            this.menuItem_clipboard.Name = "menuItem_clipboard";
-            this.menuItem_clipboard.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_clipboard.Text = "Clipboard";
-            this.menuItem_clipboard.Click += new System.EventHandler(this.menuItem_clipboard_Click);
+            menuItem_clipboard.Name = "menuItem_clipboard";
+            menuItem_clipboard.Size = new System.Drawing.Size(204, 22);
+            menuItem_clipboard.Text = "Clipboard";
+            menuItem_clipboard.Click += menuItem_clipboard_Click;
             // 
             // menuItem_zoom
             // 
-            this.menuItem_zoom.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_zoom100,
-            this.menuItem_zoom200,
-            this.menuItem_zoom400,
-            this.menuItem_zoom800,
-            this.toolStripSeparator20,
-            this.menuItem_zoomIn,
-            this.menuItem_zoomOut});
-            this.menuItem_zoom.Name = "menuItem_zoom";
-            this.menuItem_zoom.Size = new System.Drawing.Size(204, 22);
-            this.menuItem_zoom.Text = "Zoom";
+            menuItem_zoom.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_zoom100, menuItem_zoom200, menuItem_zoom400, menuItem_zoom800, toolStripSeparator20, menuItem_zoomIn, menuItem_zoomOut });
+            menuItem_zoom.Name = "menuItem_zoom";
+            menuItem_zoom.Size = new System.Drawing.Size(204, 22);
+            menuItem_zoom.Text = "Zoom";
             // 
             // menuItem_zoom100
             // 
-            this.menuItem_zoom100.Name = "menuItem_zoom100";
-            this.menuItem_zoom100.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D0)));
-            this.menuItem_zoom100.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoom100.Text = "100%";
-            this.menuItem_zoom100.Click += new System.EventHandler(this.menuItem_zoom100_Click);
+            menuItem_zoom100.Name = "menuItem_zoom100";
+            menuItem_zoom100.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D0;
+            menuItem_zoom100.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoom100.Text = "100%";
+            menuItem_zoom100.Click += menuItem_zoom100_Click;
             // 
             // menuItem_zoom200
             // 
-            this.menuItem_zoom200.Name = "menuItem_zoom200";
-            this.menuItem_zoom200.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoom200.Text = "200%";
-            this.menuItem_zoom200.Click += new System.EventHandler(this.menuItem_zoom200_Click);
+            menuItem_zoom200.Name = "menuItem_zoom200";
+            menuItem_zoom200.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoom200.Text = "200%";
+            menuItem_zoom200.Click += menuItem_zoom200_Click;
             // 
             // menuItem_zoom400
             // 
-            this.menuItem_zoom400.Name = "menuItem_zoom400";
-            this.menuItem_zoom400.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoom400.Text = "400%";
-            this.menuItem_zoom400.Click += new System.EventHandler(this.menuItem_zoom400_Click);
+            menuItem_zoom400.Name = "menuItem_zoom400";
+            menuItem_zoom400.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoom400.Text = "400%";
+            menuItem_zoom400.Click += menuItem_zoom400_Click;
             // 
             // menuItem_zoom800
             // 
-            this.menuItem_zoom800.Name = "menuItem_zoom800";
-            this.menuItem_zoom800.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoom800.Text = "800%";
-            this.menuItem_zoom800.Click += new System.EventHandler(this.menuItem_zoom800_Click);
+            menuItem_zoom800.Name = "menuItem_zoom800";
+            menuItem_zoom800.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoom800.Text = "800%";
+            menuItem_zoom800.Click += menuItem_zoom800_Click;
             // 
             // toolStripSeparator20
             // 
-            this.toolStripSeparator20.Name = "toolStripSeparator20";
-            this.toolStripSeparator20.Size = new System.Drawing.Size(160, 6);
+            toolStripSeparator20.Name = "toolStripSeparator20";
+            toolStripSeparator20.Size = new System.Drawing.Size(160, 6);
             // 
             // menuItem_zoomIn
             // 
-            this.menuItem_zoomIn.Name = "menuItem_zoomIn";
-            this.menuItem_zoomIn.ShortcutKeyDisplayString = "Ctrl +";
-            this.menuItem_zoomIn.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Oemplus)));
-            this.menuItem_zoomIn.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoomIn.Text = "Zoom In";
-            this.menuItem_zoomIn.Click += new System.EventHandler(this.menuItem_zoomIn_Click);
+            menuItem_zoomIn.Name = "menuItem_zoomIn";
+            menuItem_zoomIn.ShortcutKeyDisplayString = "Ctrl +";
+            menuItem_zoomIn.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Oemplus;
+            menuItem_zoomIn.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoomIn.Text = "Zoom In";
+            menuItem_zoomIn.Click += menuItem_zoomIn_Click;
             // 
             // menuItem_zoomOut
             // 
-            this.menuItem_zoomOut.Name = "menuItem_zoomOut";
-            this.menuItem_zoomOut.ShortcutKeyDisplayString = "Ctrl -";
-            this.menuItem_zoomOut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.OemMinus)));
-            this.menuItem_zoomOut.Size = new System.Drawing.Size(163, 22);
-            this.menuItem_zoomOut.Text = "Zoom Out";
-            this.menuItem_zoomOut.Click += new System.EventHandler(this.menuItem_zoomOut_Click);
+            menuItem_zoomOut.Name = "menuItem_zoomOut";
+            menuItem_zoomOut.ShortcutKeyDisplayString = "Ctrl -";
+            menuItem_zoomOut.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.OemMinus;
+            menuItem_zoomOut.Size = new System.Drawing.Size(163, 22);
+            menuItem_zoomOut.Text = "Zoom Out";
+            menuItem_zoomOut.Click += menuItem_zoomOut_Click;
             // 
             // menuStrip_editors
             // 
-            this.menuStrip_editors.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_headerEditor,
-            this.menuItem_tilesetEditor,
-            this.toolStripSeparator24,
-            this.menuItem_graphicsEditor,
-            this.menuItem_paletteEditor,
-            this.menuItem_tileTableEditor,
-            this.menuItem_animationEditor,
-            this.toolStripSeparator25,
-            this.menuItem_spriteEditor,
-            this.menuItem_spritesetEditor,
-            this.menuItem_minimapEditor,
-            this.menuItem_connectionEditor,
-            this.toolStripSeparator26,
-            this.menuItem_textEditor,
-            this.menuItem_demoEditor,
-            this.menuItem_physicsEditor,
-            this.menuItem_weaponEditor});
-            this.menuStrip_editors.Enabled = false;
-            this.menuStrip_editors.Name = "menuStrip_editors";
-            this.menuStrip_editors.Size = new System.Drawing.Size(55, 20);
-            this.menuStrip_editors.Text = "Editors";
+            menuStrip_editors.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_headerEditor, menuItem_tilesetEditor, toolStripSeparator24, menuItem_graphicsEditor, menuItem_paletteEditor, menuItem_tileTableEditor, menuItem_animationEditor, toolStripSeparator25, menuItem_spriteEditor, menuItem_spritesetEditor, menuItem_minimapEditor, menuItem_connectionEditor, toolStripSeparator26, menuItem_textEditor, menuItem_demoEditor, menuItem_physicsEditor, menuItem_weaponEditor });
+            menuStrip_editors.Enabled = false;
+            menuStrip_editors.Name = "menuStrip_editors";
+            menuStrip_editors.Size = new System.Drawing.Size(55, 20);
+            menuStrip_editors.Text = "Editors";
             // 
             // menuItem_headerEditor
             // 
-            this.menuItem_headerEditor.Name = "menuItem_headerEditor";
-            this.menuItem_headerEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_headerEditor.Text = "Header Editor";
-            this.menuItem_headerEditor.Click += new System.EventHandler(this.menuItem_headerEditor_Click);
+            menuItem_headerEditor.Name = "menuItem_headerEditor";
+            menuItem_headerEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_headerEditor.Text = "Header Editor";
+            menuItem_headerEditor.Click += menuItem_headerEditor_Click;
             // 
             // menuItem_tilesetEditor
             // 
-            this.menuItem_tilesetEditor.Name = "menuItem_tilesetEditor";
-            this.menuItem_tilesetEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_tilesetEditor.Text = "Tileset Editor";
-            this.menuItem_tilesetEditor.Click += new System.EventHandler(this.menuItem_tilesetEditor_Click);
+            menuItem_tilesetEditor.Name = "menuItem_tilesetEditor";
+            menuItem_tilesetEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_tilesetEditor.Text = "Tileset Editor";
+            menuItem_tilesetEditor.Click += menuItem_tilesetEditor_Click;
             // 
             // toolStripSeparator24
             // 
-            this.toolStripSeparator24.Name = "toolStripSeparator24";
-            this.toolStripSeparator24.Size = new System.Drawing.Size(167, 6);
+            toolStripSeparator24.Name = "toolStripSeparator24";
+            toolStripSeparator24.Size = new System.Drawing.Size(167, 6);
             // 
             // menuItem_graphicsEditor
             // 
-            this.menuItem_graphicsEditor.Name = "menuItem_graphicsEditor";
-            this.menuItem_graphicsEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_graphicsEditor.Text = "Graphics Editor";
-            this.menuItem_graphicsEditor.Click += new System.EventHandler(this.menuItem_graphicsEditor_Click);
+            menuItem_graphicsEditor.Name = "menuItem_graphicsEditor";
+            menuItem_graphicsEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_graphicsEditor.Text = "Graphics Editor";
+            menuItem_graphicsEditor.Click += menuItem_graphicsEditor_Click;
             // 
             // menuItem_paletteEditor
             // 
-            this.menuItem_paletteEditor.Name = "menuItem_paletteEditor";
-            this.menuItem_paletteEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_paletteEditor.Text = "Palette Editor";
-            this.menuItem_paletteEditor.Click += new System.EventHandler(this.menuItem_paletteEditor_Click);
+            menuItem_paletteEditor.Name = "menuItem_paletteEditor";
+            menuItem_paletteEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_paletteEditor.Text = "Palette Editor";
+            menuItem_paletteEditor.Click += menuItem_paletteEditor_Click;
             // 
             // menuItem_tileTableEditor
             // 
-            this.menuItem_tileTableEditor.Name = "menuItem_tileTableEditor";
-            this.menuItem_tileTableEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_tileTableEditor.Text = "Tile Table Editor";
-            this.menuItem_tileTableEditor.Click += new System.EventHandler(this.menuItem_tileTableEditor_Click);
+            menuItem_tileTableEditor.Name = "menuItem_tileTableEditor";
+            menuItem_tileTableEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_tileTableEditor.Text = "Tile Table Editor";
+            menuItem_tileTableEditor.Click += menuItem_tileTableEditor_Click;
             // 
             // menuItem_animationEditor
             // 
-            this.menuItem_animationEditor.Name = "menuItem_animationEditor";
-            this.menuItem_animationEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_animationEditor.Text = "Animation Editor";
-            this.menuItem_animationEditor.Click += new System.EventHandler(this.menuItem_animationEditor_Click);
+            menuItem_animationEditor.Name = "menuItem_animationEditor";
+            menuItem_animationEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_animationEditor.Text = "Animation Editor";
+            menuItem_animationEditor.Click += menuItem_animationEditor_Click;
             // 
             // toolStripSeparator25
             // 
-            this.toolStripSeparator25.Name = "toolStripSeparator25";
-            this.toolStripSeparator25.Size = new System.Drawing.Size(167, 6);
+            toolStripSeparator25.Name = "toolStripSeparator25";
+            toolStripSeparator25.Size = new System.Drawing.Size(167, 6);
             // 
             // menuItem_spriteEditor
             // 
-            this.menuItem_spriteEditor.Name = "menuItem_spriteEditor";
-            this.menuItem_spriteEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_spriteEditor.Text = "Sprite Editor";
-            this.menuItem_spriteEditor.Click += new System.EventHandler(this.menuItem_spriteEditor_Click);
+            menuItem_spriteEditor.Name = "menuItem_spriteEditor";
+            menuItem_spriteEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_spriteEditor.Text = "Sprite Editor";
+            menuItem_spriteEditor.Click += menuItem_spriteEditor_Click;
             // 
             // menuItem_spritesetEditor
             // 
-            this.menuItem_spritesetEditor.Name = "menuItem_spritesetEditor";
-            this.menuItem_spritesetEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_spritesetEditor.Text = "Spriteset Editor";
-            this.menuItem_spritesetEditor.Click += new System.EventHandler(this.menuItem_spritesetEditor_Click);
+            menuItem_spritesetEditor.Name = "menuItem_spritesetEditor";
+            menuItem_spritesetEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_spritesetEditor.Text = "Spriteset Editor";
+            menuItem_spritesetEditor.Click += menuItem_spritesetEditor_Click;
             // 
             // menuItem_minimapEditor
             // 
-            this.menuItem_minimapEditor.Name = "menuItem_minimapEditor";
-            this.menuItem_minimapEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_minimapEditor.Text = "Minimap Editor";
-            this.menuItem_minimapEditor.Click += new System.EventHandler(this.menuItem_minimapEditor_Click);
+            menuItem_minimapEditor.Name = "menuItem_minimapEditor";
+            menuItem_minimapEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_minimapEditor.Text = "Minimap Editor";
+            menuItem_minimapEditor.Click += menuItem_minimapEditor_Click;
             // 
             // menuItem_connectionEditor
             // 
-            this.menuItem_connectionEditor.Name = "menuItem_connectionEditor";
-            this.menuItem_connectionEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_connectionEditor.Text = "Connection Editor";
-            this.menuItem_connectionEditor.Click += new System.EventHandler(this.menuItem_connectionEditor_Click);
+            menuItem_connectionEditor.Name = "menuItem_connectionEditor";
+            menuItem_connectionEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_connectionEditor.Text = "Connection Editor";
+            menuItem_connectionEditor.Click += menuItem_connectionEditor_Click;
             // 
             // toolStripSeparator26
             // 
-            this.toolStripSeparator26.Name = "toolStripSeparator26";
-            this.toolStripSeparator26.Size = new System.Drawing.Size(167, 6);
+            toolStripSeparator26.Name = "toolStripSeparator26";
+            toolStripSeparator26.Size = new System.Drawing.Size(167, 6);
             // 
             // menuItem_textEditor
             // 
-            this.menuItem_textEditor.Name = "menuItem_textEditor";
-            this.menuItem_textEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_textEditor.Text = "Text Editor";
-            this.menuItem_textEditor.Click += new System.EventHandler(this.menuItem_textEditor_Click);
+            menuItem_textEditor.Name = "menuItem_textEditor";
+            menuItem_textEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_textEditor.Text = "Text Editor";
+            menuItem_textEditor.Click += menuItem_textEditor_Click;
             // 
             // menuItem_demoEditor
             // 
-            this.menuItem_demoEditor.Name = "menuItem_demoEditor";
-            this.menuItem_demoEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_demoEditor.Text = "Demo Editor";
-            this.menuItem_demoEditor.Click += new System.EventHandler(this.menuItem_demoEditor_Click);
+            menuItem_demoEditor.Name = "menuItem_demoEditor";
+            menuItem_demoEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_demoEditor.Text = "Demo Editor";
+            menuItem_demoEditor.Click += menuItem_demoEditor_Click;
             // 
             // menuItem_physicsEditor
             // 
-            this.menuItem_physicsEditor.Name = "menuItem_physicsEditor";
-            this.menuItem_physicsEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_physicsEditor.Text = "Physics Editor";
-            this.menuItem_physicsEditor.Click += new System.EventHandler(this.menuItem_physicsEditor_Click);
+            menuItem_physicsEditor.Name = "menuItem_physicsEditor";
+            menuItem_physicsEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_physicsEditor.Text = "Physics Editor";
+            menuItem_physicsEditor.Click += menuItem_physicsEditor_Click;
             // 
             // menuItem_weaponEditor
             // 
-            this.menuItem_weaponEditor.Name = "menuItem_weaponEditor";
-            this.menuItem_weaponEditor.Size = new System.Drawing.Size(170, 22);
-            this.menuItem_weaponEditor.Text = "Weapon Editor";
-            this.menuItem_weaponEditor.Click += new System.EventHandler(this.menuItem_weaponEditor_Click);
+            menuItem_weaponEditor.Name = "menuItem_weaponEditor";
+            menuItem_weaponEditor.Size = new System.Drawing.Size(170, 22);
+            menuItem_weaponEditor.Text = "Weapon Editor";
+            menuItem_weaponEditor.Click += menuItem_weaponEditor_Click;
             // 
             // menuStrip_tools
             // 
-            this.menuStrip_tools.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_roomOptions,
-            this.menuItem_testRoom,
-            this.menuItem_clipShortcuts,
-            this.toolStripSeparator2,
-            this.menuItem_import,
-            this.menuItem_export,
-            this.menuItem_compression,
-            this.toolStripSeparator23,
-            this.menuItem_tileBuilder,
-            this.menuItem_add,
-            this.menuItem_patches});
-            this.menuStrip_tools.Enabled = false;
-            this.menuStrip_tools.Name = "menuStrip_tools";
-            this.menuStrip_tools.Size = new System.Drawing.Size(46, 20);
-            this.menuStrip_tools.Text = "Tools";
+            menuStrip_tools.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_roomOptions, menuItem_testRoom, menuItem_clipShortcuts, toolStripSeparator2, menuItem_import, menuItem_export, menuItem_compression, toolStripSeparator23, menuItem_tileBuilder, menuItem_add, menuItem_patches });
+            menuStrip_tools.Enabled = false;
+            menuStrip_tools.Name = "menuStrip_tools";
+            menuStrip_tools.Size = new System.Drawing.Size(46, 20);
+            menuStrip_tools.Text = "Tools";
             // 
             // menuItem_roomOptions
             // 
-            this.menuItem_roomOptions.Name = "menuItem_roomOptions";
-            this.menuItem_roomOptions.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_roomOptions.Text = "Room Options...";
-            this.menuItem_roomOptions.Click += new System.EventHandler(this.menuItem_roomOptions_Click);
+            menuItem_roomOptions.Name = "menuItem_roomOptions";
+            menuItem_roomOptions.Size = new System.Drawing.Size(183, 22);
+            menuItem_roomOptions.Text = "Room Options...";
+            menuItem_roomOptions.Click += menuItem_roomOptions_Click;
             // 
             // menuItem_testRoom
             // 
-            this.menuItem_testRoom.Name = "menuItem_testRoom";
-            this.menuItem_testRoom.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_testRoom.Text = "Test Room...";
-            this.menuItem_testRoom.Click += new System.EventHandler(this.menuItem_testRoom_Click);
+            menuItem_testRoom.Name = "menuItem_testRoom";
+            menuItem_testRoom.Size = new System.Drawing.Size(183, 22);
+            menuItem_testRoom.Text = "Test Room...";
+            menuItem_testRoom.Click += menuItem_testRoom_Click;
             // 
             // menuItem_clipShortcuts
             // 
-            this.menuItem_clipShortcuts.Name = "menuItem_clipShortcuts";
-            this.menuItem_clipShortcuts.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_clipShortcuts.Text = "Clipdata Shortcuts";
-            this.menuItem_clipShortcuts.Click += new System.EventHandler(this.menuItem_clipShortcuts_Click);
+            menuItem_clipShortcuts.Name = "menuItem_clipShortcuts";
+            menuItem_clipShortcuts.Size = new System.Drawing.Size(183, 22);
+            menuItem_clipShortcuts.Text = "Clipdata Shortcuts";
+            menuItem_clipShortcuts.Click += menuItem_clipShortcuts_Click;
             // 
             // toolStripSeparator2
             // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(180, 6);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new System.Drawing.Size(180, 6);
             // 
             // menuItem_import
             // 
-            this.menuItem_import.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_importTileset,
-            this.menuItem_importRLE,
-            this.menuItem_importLZ77,
-            this.menuItem_importRoom,
-            this.toolStripSeparator8,
-            this.menuItem_importTilesetImage,
-            this.menuItem_importLZ77BGimage,
-            this.menuItem_importEnding});
-            this.menuItem_import.Name = "menuItem_import";
-            this.menuItem_import.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_import.Text = "Import";
+            menuItem_import.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_importTileset, menuItem_importRLE, menuItem_importLZ77, menuItem_importRoom, toolStripSeparator8, menuItem_importTilesetImage, menuItem_importLZ77BGimage, menuItem_importEnding });
+            menuItem_import.Name = "menuItem_import";
+            menuItem_import.Size = new System.Drawing.Size(183, 22);
+            menuItem_import.Text = "Import";
             // 
             // menuItem_importTileset
             // 
-            this.menuItem_importTileset.Name = "menuItem_importTileset";
-            this.menuItem_importTileset.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importTileset.Text = "Tileset...";
-            this.menuItem_importTileset.Click += new System.EventHandler(this.menuItem_importTileset_Click);
+            menuItem_importTileset.Name = "menuItem_importTileset";
+            menuItem_importTileset.Size = new System.Drawing.Size(191, 22);
+            menuItem_importTileset.Text = "Tileset...";
+            menuItem_importTileset.Click += menuItem_importTileset_Click;
             // 
             // menuItem_importRLE
             // 
-            this.menuItem_importRLE.Name = "menuItem_importRLE";
-            this.menuItem_importRLE.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importRLE.Text = "RLE Background...";
-            this.menuItem_importRLE.Click += new System.EventHandler(this.menuItem_importRLE_Click);
+            menuItem_importRLE.Name = "menuItem_importRLE";
+            menuItem_importRLE.Size = new System.Drawing.Size(191, 22);
+            menuItem_importRLE.Text = "RLE Background...";
+            menuItem_importRLE.Click += menuItem_importRLE_Click;
             // 
             // menuItem_importLZ77
             // 
-            this.menuItem_importLZ77.Name = "menuItem_importLZ77";
-            this.menuItem_importLZ77.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importLZ77.Text = "LZ77 Background...";
-            this.menuItem_importLZ77.Click += new System.EventHandler(this.menuItem_importLZ77_Click);
+            menuItem_importLZ77.Name = "menuItem_importLZ77";
+            menuItem_importLZ77.Size = new System.Drawing.Size(191, 22);
+            menuItem_importLZ77.Text = "LZ77 Background...";
+            menuItem_importLZ77.Click += menuItem_importLZ77_Click;
             // 
             // menuItem_importRoom
             // 
-            this.menuItem_importRoom.Name = "menuItem_importRoom";
-            this.menuItem_importRoom.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importRoom.Text = "Room...";
-            this.menuItem_importRoom.Click += new System.EventHandler(this.menuItem_importRoom_Click);
+            menuItem_importRoom.Name = "menuItem_importRoom";
+            menuItem_importRoom.Size = new System.Drawing.Size(191, 22);
+            menuItem_importRoom.Text = "Room...";
+            menuItem_importRoom.Click += menuItem_importRoom_Click;
             // 
             // toolStripSeparator8
             // 
-            this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(188, 6);
+            toolStripSeparator8.Name = "toolStripSeparator8";
+            toolStripSeparator8.Size = new System.Drawing.Size(188, 6);
             // 
             // menuItem_importTilesetImage
             // 
-            this.menuItem_importTilesetImage.Name = "menuItem_importTilesetImage";
-            this.menuItem_importTilesetImage.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importTilesetImage.Text = "Tileset from Image...";
-            this.menuItem_importTilesetImage.Click += new System.EventHandler(this.menuItem_importTilesetImage_Click);
+            menuItem_importTilesetImage.Name = "menuItem_importTilesetImage";
+            menuItem_importTilesetImage.Size = new System.Drawing.Size(191, 22);
+            menuItem_importTilesetImage.Text = "Tileset from Image...";
+            menuItem_importTilesetImage.Click += menuItem_importTilesetImage_Click;
             // 
             // menuItem_importLZ77BGimage
             // 
-            this.menuItem_importLZ77BGimage.Name = "menuItem_importLZ77BGimage";
-            this.menuItem_importLZ77BGimage.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importLZ77BGimage.Text = "LZ77 BG from Image...";
-            this.menuItem_importLZ77BGimage.Click += new System.EventHandler(this.menuItem_importLZ77BGimage_Click);
+            menuItem_importLZ77BGimage.Name = "menuItem_importLZ77BGimage";
+            menuItem_importLZ77BGimage.Size = new System.Drawing.Size(191, 22);
+            menuItem_importLZ77BGimage.Text = "LZ77 BG from Image...";
+            menuItem_importLZ77BGimage.Click += menuItem_importLZ77BGimage_Click;
             // 
             // menuItem_importEnding
             // 
-            this.menuItem_importEnding.Name = "menuItem_importEnding";
-            this.menuItem_importEnding.Size = new System.Drawing.Size(191, 22);
-            this.menuItem_importEnding.Text = "Ending from Image";
-            this.menuItem_importEnding.Click += new System.EventHandler(this.menuItem_importEnding_Click);
+            menuItem_importEnding.Name = "menuItem_importEnding";
+            menuItem_importEnding.Size = new System.Drawing.Size(191, 22);
+            menuItem_importEnding.Text = "Ending from Image";
+            menuItem_importEnding.Click += menuItem_importEnding_Click;
             // 
             // menuItem_export
             // 
-            this.menuItem_export.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_exportTileset,
-            this.menuItem_exportBG,
-            this.menuItem_exportRoom,
-            this.toolStripSeparator7,
-            this.menuItem_exportTilesetImage,
-            this.menuItem_exportBG0image,
-            this.menuItem_exportBG3image,
-            this.menuItem_exportRoomImage});
-            this.menuItem_export.Name = "menuItem_export";
-            this.menuItem_export.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_export.Text = "Export";
+            menuItem_export.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_exportTileset, menuItem_exportBG, menuItem_exportRoom, toolStripSeparator7, menuItem_exportTilesetImage, menuItem_exportBG0image, menuItem_exportBG3image, menuItem_exportRoomImage });
+            menuItem_export.Name = "menuItem_export";
+            menuItem_export.Size = new System.Drawing.Size(183, 22);
+            menuItem_export.Text = "Export";
             // 
             // menuItem_exportTileset
             // 
-            this.menuItem_exportTileset.Name = "menuItem_exportTileset";
-            this.menuItem_exportTileset.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportTileset.Text = "Tileset...";
-            this.menuItem_exportTileset.Click += new System.EventHandler(this.menuItem_exportTileset_Click);
+            menuItem_exportTileset.Name = "menuItem_exportTileset";
+            menuItem_exportTileset.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportTileset.Text = "Tileset...";
+            menuItem_exportTileset.Click += menuItem_exportTileset_Click;
             // 
             // menuItem_exportBG
             // 
-            this.menuItem_exportBG.Name = "menuItem_exportBG";
-            this.menuItem_exportBG.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportBG.Text = "Background...";
-            this.menuItem_exportBG.Click += new System.EventHandler(this.menuItem_exportBG_Click);
+            menuItem_exportBG.Name = "menuItem_exportBG";
+            menuItem_exportBG.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportBG.Text = "Background...";
+            menuItem_exportBG.Click += menuItem_exportBG_Click;
             // 
             // menuItem_exportRoom
             // 
-            this.menuItem_exportRoom.Name = "menuItem_exportRoom";
-            this.menuItem_exportRoom.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportRoom.Text = "Room...";
-            this.menuItem_exportRoom.Click += new System.EventHandler(this.menuItem_exportRoom_Click);
+            menuItem_exportRoom.Name = "menuItem_exportRoom";
+            menuItem_exportRoom.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportRoom.Text = "Room...";
+            menuItem_exportRoom.Click += menuItem_exportRoom_Click;
             // 
             // toolStripSeparator7
             // 
-            this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(149, 6);
+            toolStripSeparator7.Name = "toolStripSeparator7";
+            toolStripSeparator7.Size = new System.Drawing.Size(149, 6);
             // 
             // menuItem_exportTilesetImage
             // 
-            this.menuItem_exportTilesetImage.Name = "menuItem_exportTilesetImage";
-            this.menuItem_exportTilesetImage.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportTilesetImage.Text = "Tileset Image...";
-            this.menuItem_exportTilesetImage.Click += new System.EventHandler(this.menuItem_exportTilesetImage_Click);
+            menuItem_exportTilesetImage.Name = "menuItem_exportTilesetImage";
+            menuItem_exportTilesetImage.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportTilesetImage.Text = "Tileset Image...";
+            menuItem_exportTilesetImage.Click += menuItem_exportTilesetImage_Click;
             // 
             // menuItem_exportBG0image
             // 
-            this.menuItem_exportBG0image.Name = "menuItem_exportBG0image";
-            this.menuItem_exportBG0image.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportBG0image.Text = "BG0 Image...";
-            this.menuItem_exportBG0image.Click += new System.EventHandler(this.menuItem_exportBG0image_Click);
+            menuItem_exportBG0image.Name = "menuItem_exportBG0image";
+            menuItem_exportBG0image.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportBG0image.Text = "BG0 Image...";
+            menuItem_exportBG0image.Click += menuItem_exportBG0image_Click;
             // 
             // menuItem_exportBG3image
             // 
-            this.menuItem_exportBG3image.Name = "menuItem_exportBG3image";
-            this.menuItem_exportBG3image.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportBG3image.Text = "BG3 Image...";
-            this.menuItem_exportBG3image.Click += new System.EventHandler(this.menuItem_exportBG3image_Click);
+            menuItem_exportBG3image.Name = "menuItem_exportBG3image";
+            menuItem_exportBG3image.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportBG3image.Text = "BG3 Image...";
+            menuItem_exportBG3image.Click += menuItem_exportBG3image_Click;
             // 
             // menuItem_exportRoomImage
             // 
-            this.menuItem_exportRoomImage.Name = "menuItem_exportRoomImage";
-            this.menuItem_exportRoomImage.Size = new System.Drawing.Size(152, 22);
-            this.menuItem_exportRoomImage.Text = "Room Image...";
-            this.menuItem_exportRoomImage.Click += new System.EventHandler(this.menuItem_exportRoomImage_Click);
+            menuItem_exportRoomImage.Name = "menuItem_exportRoomImage";
+            menuItem_exportRoomImage.Size = new System.Drawing.Size(152, 22);
+            menuItem_exportRoomImage.Text = "Room Image...";
+            menuItem_exportRoomImage.Click += menuItem_exportRoomImage_Click;
             // 
             // menuItem_compression
             // 
-            this.menuItem_compression.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_LZ77comp,
-            this.menuItem_LZ77decomp});
-            this.menuItem_compression.Name = "menuItem_compression";
-            this.menuItem_compression.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_compression.Text = "Compression";
+            menuItem_compression.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_LZ77comp, menuItem_LZ77decomp });
+            menuItem_compression.Name = "menuItem_compression";
+            menuItem_compression.Size = new System.Drawing.Size(183, 22);
+            menuItem_compression.Text = "Compression";
             // 
             // menuItem_LZ77comp
             // 
-            this.menuItem_LZ77comp.Name = "menuItem_LZ77comp";
-            this.menuItem_LZ77comp.Size = new System.Drawing.Size(197, 22);
-            this.menuItem_LZ77comp.Text = "LZ77 Compress File...";
-            this.menuItem_LZ77comp.Click += new System.EventHandler(this.menuItem_LZ77comp_Click);
+            menuItem_LZ77comp.Name = "menuItem_LZ77comp";
+            menuItem_LZ77comp.Size = new System.Drawing.Size(197, 22);
+            menuItem_LZ77comp.Text = "LZ77 Compress File...";
+            menuItem_LZ77comp.Click += menuItem_LZ77comp_Click;
             // 
             // menuItem_LZ77decomp
             // 
-            this.menuItem_LZ77decomp.Name = "menuItem_LZ77decomp";
-            this.menuItem_LZ77decomp.Size = new System.Drawing.Size(197, 22);
-            this.menuItem_LZ77decomp.Text = "LZ77 Decompress File...";
-            this.menuItem_LZ77decomp.Click += new System.EventHandler(this.menuItem_LZ77decomp_Click);
+            menuItem_LZ77decomp.Name = "menuItem_LZ77decomp";
+            menuItem_LZ77decomp.Size = new System.Drawing.Size(197, 22);
+            menuItem_LZ77decomp.Text = "LZ77 Decompress File...";
+            menuItem_LZ77decomp.Click += menuItem_LZ77decomp_Click;
             // 
             // toolStripSeparator23
             // 
-            this.toolStripSeparator23.Name = "toolStripSeparator23";
-            this.toolStripSeparator23.Size = new System.Drawing.Size(180, 6);
+            toolStripSeparator23.Name = "toolStripSeparator23";
+            toolStripSeparator23.Size = new System.Drawing.Size(180, 6);
             // 
             // menuItem_tileBuilder
             // 
-            this.menuItem_tileBuilder.Name = "menuItem_tileBuilder";
-            this.menuItem_tileBuilder.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_tileBuilder.Text = "Minimap Tile Builder";
-            this.menuItem_tileBuilder.Click += new System.EventHandler(this.menuItem_tileBuilder_Click);
+            menuItem_tileBuilder.Name = "menuItem_tileBuilder";
+            menuItem_tileBuilder.Size = new System.Drawing.Size(183, 22);
+            menuItem_tileBuilder.Text = "Minimap Tile Builder";
+            menuItem_tileBuilder.Click += menuItem_tileBuilder_Click;
             // 
             // menuItem_add
             // 
-            this.menuItem_add.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_addBG,
-            this.menuItem_addEnemyset,
-            this.menuItem_addRoom,
-            this.menuItem_addTileset,
-            this.menuItem_addSpriteset,
-            this.menuItem_addAnim});
-            this.menuItem_add.Name = "menuItem_add";
-            this.menuItem_add.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_add.Text = "Add";
+            menuItem_add.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_addBG, menuItem_addEnemyset, menuItem_addRoom, menuItem_addTileset, menuItem_addSpriteset, menuItem_addAnim });
+            menuItem_add.Name = "menuItem_add";
+            menuItem_add.Size = new System.Drawing.Size(183, 22);
+            menuItem_add.Text = "Add";
             // 
             // menuItem_addBG
             // 
-            this.menuItem_addBG.Name = "menuItem_addBG";
-            this.menuItem_addBG.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addBG.Text = "Background";
-            this.menuItem_addBG.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addBG.Name = "menuItem_addBG";
+            menuItem_addBG.Size = new System.Drawing.Size(144, 22);
+            menuItem_addBG.Text = "Background";
+            menuItem_addBG.Click += menuItem_addItem_Click;
             // 
             // menuItem_addEnemyset
             // 
-            this.menuItem_addEnemyset.Name = "menuItem_addEnemyset";
-            this.menuItem_addEnemyset.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addEnemyset.Text = "Room Sprites";
-            this.menuItem_addEnemyset.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addEnemyset.Name = "menuItem_addEnemyset";
+            menuItem_addEnemyset.Size = new System.Drawing.Size(144, 22);
+            menuItem_addEnemyset.Text = "Room Sprites";
+            menuItem_addEnemyset.Click += menuItem_addItem_Click;
             // 
             // menuItem_addRoom
             // 
-            this.menuItem_addRoom.Name = "menuItem_addRoom";
-            this.menuItem_addRoom.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addRoom.Text = "Room";
-            this.menuItem_addRoom.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addRoom.Name = "menuItem_addRoom";
+            menuItem_addRoom.Size = new System.Drawing.Size(144, 22);
+            menuItem_addRoom.Text = "Room";
+            menuItem_addRoom.Click += menuItem_addItem_Click;
             // 
             // menuItem_addTileset
             // 
-            this.menuItem_addTileset.Name = "menuItem_addTileset";
-            this.menuItem_addTileset.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addTileset.Text = "Tileset";
-            this.menuItem_addTileset.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addTileset.Name = "menuItem_addTileset";
+            menuItem_addTileset.Size = new System.Drawing.Size(144, 22);
+            menuItem_addTileset.Text = "Tileset";
+            menuItem_addTileset.Click += menuItem_addItem_Click;
             // 
             // menuItem_addSpriteset
             // 
-            this.menuItem_addSpriteset.Name = "menuItem_addSpriteset";
-            this.menuItem_addSpriteset.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addSpriteset.Text = "Spriteset";
-            this.menuItem_addSpriteset.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addSpriteset.Name = "menuItem_addSpriteset";
+            menuItem_addSpriteset.Size = new System.Drawing.Size(144, 22);
+            menuItem_addSpriteset.Text = "Spriteset";
+            menuItem_addSpriteset.Click += menuItem_addItem_Click;
             // 
             // menuItem_addAnim
             // 
-            this.menuItem_addAnim.Name = "menuItem_addAnim";
-            this.menuItem_addAnim.Size = new System.Drawing.Size(144, 22);
-            this.menuItem_addAnim.Text = "Animation";
-            this.menuItem_addAnim.Click += new System.EventHandler(this.menuItem_addItem_Click);
+            menuItem_addAnim.Name = "menuItem_addAnim";
+            menuItem_addAnim.Size = new System.Drawing.Size(144, 22);
+            menuItem_addAnim.Text = "Animation";
+            menuItem_addAnim.Click += menuItem_addItem_Click;
             // 
             // menuItem_patches
             // 
-            this.menuItem_patches.Name = "menuItem_patches";
-            this.menuItem_patches.Size = new System.Drawing.Size(183, 22);
-            this.menuItem_patches.Text = "Patches";
-            this.menuItem_patches.Click += new System.EventHandler(this.menuItem_patches_Click);
+            menuItem_patches.Name = "menuItem_patches";
+            menuItem_patches.Size = new System.Drawing.Size(183, 22);
+            menuItem_patches.Text = "Patches";
+            menuItem_patches.Click += menuItem_patches_Click;
             // 
             // menuStrip_options
             // 
-            this.menuStrip_options.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_defaultView,
-            this.menuItem_numberBase,
-            this.toolStripSeparator28,
-            this.themeToolStripMenuItem,
-            this.toolStripSeparator21,
-            this.menuItem_tooltips});
-            this.menuStrip_options.Name = "menuStrip_options";
-            this.menuStrip_options.Size = new System.Drawing.Size(61, 20);
-            this.menuStrip_options.Text = "Options";
+            menuStrip_options.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_defaultView, menuItem_numberBase, toolStripSeparator28, themeToolStripMenuItem, toolStripSeparator21, menuItem_tooltips });
+            menuStrip_options.Name = "menuStrip_options";
+            menuStrip_options.Size = new System.Drawing.Size(61, 20);
+            menuStrip_options.Text = "Options";
             // 
             // menuItem_defaultView
             // 
-            this.menuItem_defaultView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_defaultBG0,
-            this.menuItem_defaultBG1,
-            this.menuItem_defaultBG2,
-            this.menuItem_defaultBG3,
-            this.menuItem_defaultClipdata,
-            this.toolStripSeparator13,
-            this.menuItem_defaultSprites,
-            this.menuItem_defaultSpriteOutlines,
-            this.menuItem_defaultDoors,
-            this.menuItem_defaultScrolls,
-            this.menuItem_defaultScreens});
-            this.menuItem_defaultView.Enabled = false;
-            this.menuItem_defaultView.Name = "menuItem_defaultView";
-            this.menuItem_defaultView.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultView.Text = "Default View";
+            menuItem_defaultView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_defaultBG0, menuItem_defaultBG1, menuItem_defaultBG2, menuItem_defaultBG3, menuItem_defaultClipdata, toolStripSeparator13, menuItem_defaultSprites, menuItem_defaultSpriteOutlines, menuItem_defaultDoors, menuItem_defaultScrolls, menuItem_defaultScreens });
+            menuItem_defaultView.Enabled = false;
+            menuItem_defaultView.Name = "menuItem_defaultView";
+            menuItem_defaultView.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultView.Text = "Default View";
             // 
             // menuItem_defaultBG0
             // 
-            this.menuItem_defaultBG0.Checked = true;
-            this.menuItem_defaultBG0.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultBG0.Name = "menuItem_defaultBG0";
-            this.menuItem_defaultBG0.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultBG0.Text = "BG 0";
-            this.menuItem_defaultBG0.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultBG0.Checked = true;
+            menuItem_defaultBG0.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultBG0.Name = "menuItem_defaultBG0";
+            menuItem_defaultBG0.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultBG0.Text = "BG 0";
+            menuItem_defaultBG0.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultBG1
             // 
-            this.menuItem_defaultBG1.Checked = true;
-            this.menuItem_defaultBG1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultBG1.Name = "menuItem_defaultBG1";
-            this.menuItem_defaultBG1.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultBG1.Text = "BG 1";
-            this.menuItem_defaultBG1.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultBG1.Checked = true;
+            menuItem_defaultBG1.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultBG1.Name = "menuItem_defaultBG1";
+            menuItem_defaultBG1.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultBG1.Text = "BG 1";
+            menuItem_defaultBG1.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultBG2
             // 
-            this.menuItem_defaultBG2.Checked = true;
-            this.menuItem_defaultBG2.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultBG2.Name = "menuItem_defaultBG2";
-            this.menuItem_defaultBG2.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultBG2.Text = "BG 2";
-            this.menuItem_defaultBG2.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultBG2.Checked = true;
+            menuItem_defaultBG2.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultBG2.Name = "menuItem_defaultBG2";
+            menuItem_defaultBG2.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultBG2.Text = "BG 2";
+            menuItem_defaultBG2.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultBG3
             // 
-            this.menuItem_defaultBG3.Checked = true;
-            this.menuItem_defaultBG3.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultBG3.Name = "menuItem_defaultBG3";
-            this.menuItem_defaultBG3.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultBG3.Text = "BG 3";
-            this.menuItem_defaultBG3.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultBG3.Checked = true;
+            menuItem_defaultBG3.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultBG3.Name = "menuItem_defaultBG3";
+            menuItem_defaultBG3.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultBG3.Text = "BG 3";
+            menuItem_defaultBG3.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultClipdata
             // 
-            this.menuItem_defaultClipdata.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_defaultClipCollision,
-            this.menuItem_defaultClipBreakable,
-            this.menuItem_defaultClipValues});
-            this.menuItem_defaultClipdata.Name = "menuItem_defaultClipdata";
-            this.menuItem_defaultClipdata.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultClipdata.Text = "Clipdata";
+            menuItem_defaultClipdata.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_defaultClipCollision, menuItem_defaultClipBreakable, menuItem_defaultClipValues });
+            menuItem_defaultClipdata.Name = "menuItem_defaultClipdata";
+            menuItem_defaultClipdata.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultClipdata.Text = "Clipdata";
             // 
             // menuItem_defaultClipCollision
             // 
-            this.menuItem_defaultClipCollision.Name = "menuItem_defaultClipCollision";
-            this.menuItem_defaultClipCollision.Size = new System.Drawing.Size(125, 22);
-            this.menuItem_defaultClipCollision.Text = "Collision";
-            this.menuItem_defaultClipCollision.Click += new System.EventHandler(this.menuItem_defaultClipToggle_Click);
+            menuItem_defaultClipCollision.Name = "menuItem_defaultClipCollision";
+            menuItem_defaultClipCollision.Size = new System.Drawing.Size(125, 22);
+            menuItem_defaultClipCollision.Text = "Collision";
+            menuItem_defaultClipCollision.Click += menuItem_defaultClipToggle_Click;
             // 
             // menuItem_defaultClipBreakable
             // 
-            this.menuItem_defaultClipBreakable.Name = "menuItem_defaultClipBreakable";
-            this.menuItem_defaultClipBreakable.Size = new System.Drawing.Size(125, 22);
-            this.menuItem_defaultClipBreakable.Text = "Breakable";
-            this.menuItem_defaultClipBreakable.Click += new System.EventHandler(this.menuItem_defaultClipToggle_Click);
+            menuItem_defaultClipBreakable.Name = "menuItem_defaultClipBreakable";
+            menuItem_defaultClipBreakable.Size = new System.Drawing.Size(125, 22);
+            menuItem_defaultClipBreakable.Text = "Breakable";
+            menuItem_defaultClipBreakable.Click += menuItem_defaultClipToggle_Click;
             // 
             // menuItem_defaultClipValues
             // 
-            this.menuItem_defaultClipValues.Name = "menuItem_defaultClipValues";
-            this.menuItem_defaultClipValues.Size = new System.Drawing.Size(125, 22);
-            this.menuItem_defaultClipValues.Text = "Values";
-            this.menuItem_defaultClipValues.Click += new System.EventHandler(this.menuItem_defaultClipToggle_Click);
+            menuItem_defaultClipValues.Name = "menuItem_defaultClipValues";
+            menuItem_defaultClipValues.Size = new System.Drawing.Size(125, 22);
+            menuItem_defaultClipValues.Text = "Values";
+            menuItem_defaultClipValues.Click += menuItem_defaultClipToggle_Click;
             // 
             // toolStripSeparator13
             // 
-            this.toolStripSeparator13.Name = "toolStripSeparator13";
-            this.toolStripSeparator13.Size = new System.Drawing.Size(153, 6);
+            toolStripSeparator13.Name = "toolStripSeparator13";
+            toolStripSeparator13.Size = new System.Drawing.Size(153, 6);
             // 
             // menuItem_defaultSprites
             // 
-            this.menuItem_defaultSprites.Checked = true;
-            this.menuItem_defaultSprites.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultSprites.Name = "menuItem_defaultSprites";
-            this.menuItem_defaultSprites.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultSprites.Text = "Sprites";
-            this.menuItem_defaultSprites.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultSprites.Checked = true;
+            menuItem_defaultSprites.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultSprites.Name = "menuItem_defaultSprites";
+            menuItem_defaultSprites.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultSprites.Text = "Sprites";
+            menuItem_defaultSprites.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultSpriteOutlines
             // 
-            this.menuItem_defaultSpriteOutlines.Checked = true;
-            this.menuItem_defaultSpriteOutlines.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultSpriteOutlines.Name = "menuItem_defaultSpriteOutlines";
-            this.menuItem_defaultSpriteOutlines.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultSpriteOutlines.Text = "Sprite Outlines";
-            this.menuItem_defaultSpriteOutlines.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultSpriteOutlines.Checked = true;
+            menuItem_defaultSpriteOutlines.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultSpriteOutlines.Name = "menuItem_defaultSpriteOutlines";
+            menuItem_defaultSpriteOutlines.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultSpriteOutlines.Text = "Sprite Outlines";
+            menuItem_defaultSpriteOutlines.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultDoors
             // 
-            this.menuItem_defaultDoors.Checked = true;
-            this.menuItem_defaultDoors.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_defaultDoors.Name = "menuItem_defaultDoors";
-            this.menuItem_defaultDoors.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultDoors.Text = "Doors";
-            this.menuItem_defaultDoors.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultDoors.Checked = true;
+            menuItem_defaultDoors.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_defaultDoors.Name = "menuItem_defaultDoors";
+            menuItem_defaultDoors.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultDoors.Text = "Doors";
+            menuItem_defaultDoors.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultScrolls
             // 
-            this.menuItem_defaultScrolls.Name = "menuItem_defaultScrolls";
-            this.menuItem_defaultScrolls.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultScrolls.Text = "Scrolls";
-            this.menuItem_defaultScrolls.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultScrolls.Name = "menuItem_defaultScrolls";
+            menuItem_defaultScrolls.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultScrolls.Text = "Scrolls";
+            menuItem_defaultScrolls.Click += menuItem_defaultView_Click;
             // 
             // menuItem_defaultScreens
             // 
-            this.menuItem_defaultScreens.Name = "menuItem_defaultScreens";
-            this.menuItem_defaultScreens.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_defaultScreens.Text = "Screen Outlines";
-            this.menuItem_defaultScreens.Click += new System.EventHandler(this.menuItem_defaultView_Click);
+            menuItem_defaultScreens.Name = "menuItem_defaultScreens";
+            menuItem_defaultScreens.Size = new System.Drawing.Size(156, 22);
+            menuItem_defaultScreens.Text = "Screen Outlines";
+            menuItem_defaultScreens.Click += menuItem_defaultView_Click;
             // 
             // menuItem_numberBase
             // 
-            this.menuItem_numberBase.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_hexadecimal,
-            this.menuItem_decimal});
-            this.menuItem_numberBase.Enabled = false;
-            this.menuItem_numberBase.Name = "menuItem_numberBase";
-            this.menuItem_numberBase.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_numberBase.Text = "Number Base";
+            menuItem_numberBase.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_hexadecimal, menuItem_decimal });
+            menuItem_numberBase.Enabled = false;
+            menuItem_numberBase.Name = "menuItem_numberBase";
+            menuItem_numberBase.Size = new System.Drawing.Size(156, 22);
+            menuItem_numberBase.Text = "Number Base";
             // 
             // menuItem_hexadecimal
             // 
-            this.menuItem_hexadecimal.Checked = true;
-            this.menuItem_hexadecimal.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.menuItem_hexadecimal.Name = "menuItem_hexadecimal";
-            this.menuItem_hexadecimal.Size = new System.Drawing.Size(143, 22);
-            this.menuItem_hexadecimal.Text = "Hexadecimal";
-            this.menuItem_hexadecimal.Click += new System.EventHandler(this.menuItem_hexadecimal_Click);
+            menuItem_hexadecimal.Checked = true;
+            menuItem_hexadecimal.CheckState = System.Windows.Forms.CheckState.Checked;
+            menuItem_hexadecimal.Name = "menuItem_hexadecimal";
+            menuItem_hexadecimal.Size = new System.Drawing.Size(143, 22);
+            menuItem_hexadecimal.Text = "Hexadecimal";
+            menuItem_hexadecimal.Click += menuItem_hexadecimal_Click;
             // 
             // menuItem_decimal
             // 
-            this.menuItem_decimal.Name = "menuItem_decimal";
-            this.menuItem_decimal.Size = new System.Drawing.Size(143, 22);
-            this.menuItem_decimal.Text = "Decimal";
-            this.menuItem_decimal.Click += new System.EventHandler(this.menuItem_decimal_Click);
+            menuItem_decimal.Name = "menuItem_decimal";
+            menuItem_decimal.Size = new System.Drawing.Size(143, 22);
+            menuItem_decimal.Text = "Decimal";
+            menuItem_decimal.Click += menuItem_decimal_Click;
             // 
             // toolStripSeparator28
             // 
-            this.toolStripSeparator28.Name = "toolStripSeparator28";
-            this.toolStripSeparator28.Size = new System.Drawing.Size(153, 6);
+            toolStripSeparator28.Name = "toolStripSeparator28";
+            toolStripSeparator28.Size = new System.Drawing.Size(153, 6);
             // 
             // themeToolStripMenuItem
             // 
-            this.themeToolStripMenuItem.Name = "themeToolStripMenuItem";
-            this.themeToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.themeToolStripMenuItem.Text = "Theme";
-            this.themeToolStripMenuItem.Click += new System.EventHandler(this.themeToolStripMenuItem_Click);
+            themeToolStripMenuItem.Name = "themeToolStripMenuItem";
+            themeToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            themeToolStripMenuItem.Text = "Theme";
+            themeToolStripMenuItem.Click += themeToolStripMenuItem_Click;
             // 
             // toolStripSeparator21
             // 
-            this.toolStripSeparator21.Name = "toolStripSeparator21";
-            this.toolStripSeparator21.Size = new System.Drawing.Size(153, 6);
+            toolStripSeparator21.Name = "toolStripSeparator21";
+            toolStripSeparator21.Size = new System.Drawing.Size(153, 6);
             // 
             // menuItem_tooltips
             // 
-            this.menuItem_tooltips.Enabled = false;
-            this.menuItem_tooltips.Name = "menuItem_tooltips";
-            this.menuItem_tooltips.Size = new System.Drawing.Size(156, 22);
-            this.menuItem_tooltips.Text = "Disable Tooltips";
-            this.menuItem_tooltips.Click += new System.EventHandler(this.menuItem_tooltips_Click);
+            menuItem_tooltips.Enabled = false;
+            menuItem_tooltips.Name = "menuItem_tooltips";
+            menuItem_tooltips.Size = new System.Drawing.Size(156, 22);
+            menuItem_tooltips.Text = "Disable Tooltips";
+            menuItem_tooltips.Click += menuItem_tooltips_Click;
             // 
             // menuStrip_help
             // 
-            this.menuStrip_help.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuItem_viewHelp,
-            this.menuItem_about});
-            this.menuStrip_help.Name = "menuStrip_help";
-            this.menuStrip_help.Size = new System.Drawing.Size(44, 20);
-            this.menuStrip_help.Text = "Help";
+            menuStrip_help.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { menuItem_viewHelp, menuItem_about });
+            menuStrip_help.Name = "menuStrip_help";
+            menuStrip_help.Size = new System.Drawing.Size(44, 20);
+            menuStrip_help.Text = "Help";
             // 
             // menuItem_viewHelp
             // 
-            this.menuItem_viewHelp.Name = "menuItem_viewHelp";
-            this.menuItem_viewHelp.Size = new System.Drawing.Size(143, 22);
-            this.menuItem_viewHelp.Text = "View Help";
-            this.menuItem_viewHelp.Click += new System.EventHandler(this.menuItem_viewHelp_Click);
+            menuItem_viewHelp.Name = "menuItem_viewHelp";
+            menuItem_viewHelp.Size = new System.Drawing.Size(143, 22);
+            menuItem_viewHelp.Text = "View Help";
+            menuItem_viewHelp.Click += menuItem_viewHelp_Click;
             // 
             // menuItem_about
             // 
-            this.menuItem_about.Name = "menuItem_about";
-            this.menuItem_about.Size = new System.Drawing.Size(143, 22);
-            this.menuItem_about.Text = "About MAGE";
-            this.menuItem_about.Click += new System.EventHandler(this.menuItem_about_Click);
+            menuItem_about.Name = "menuItem_about";
+            menuItem_about.Size = new System.Drawing.Size(143, 22);
+            menuItem_about.Text = "About MAGE";
+            menuItem_about.Click += menuItem_about_Click;
             // 
             // groupBox_location
             // 
-            this.groupBox_location.Controls.Add(this.comboBox_room);
-            this.groupBox_location.Controls.Add(this.comboBox_area);
-            this.groupBox_location.Controls.Add(this.label_room);
-            this.groupBox_location.Controls.Add(this.label_area);
-            this.groupBox_location.Enabled = false;
-            this.groupBox_location.Location = new System.Drawing.Point(12, 52);
-            this.groupBox_location.Name = "groupBox_location";
-            this.groupBox_location.Size = new System.Drawing.Size(135, 75);
-            this.groupBox_location.TabIndex = 0;
-            this.groupBox_location.TabStop = false;
-            this.groupBox_location.Text = "Location";
+            groupBox_location.Controls.Add(comboBox_room);
+            groupBox_location.Controls.Add(comboBox_area);
+            groupBox_location.Controls.Add(label_room);
+            groupBox_location.Controls.Add(label_area);
+            groupBox_location.Enabled = false;
+            groupBox_location.Location = new System.Drawing.Point(14, 60);
+            groupBox_location.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_location.Name = "groupBox_location";
+            groupBox_location.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_location.Size = new System.Drawing.Size(158, 87);
+            groupBox_location.TabIndex = 0;
+            groupBox_location.TabStop = false;
+            groupBox_location.Text = "Location";
             // 
             // comboBox_room
             // 
-            this.comboBox_room.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_room.FormattingEnabled = true;
-            this.comboBox_room.Location = new System.Drawing.Point(49, 43);
-            this.comboBox_room.Name = "comboBox_room";
-            this.comboBox_room.Size = new System.Drawing.Size(77, 21);
-            this.comboBox_room.TabIndex = 10;
-            this.comboBox_room.SelectedIndexChanged += new System.EventHandler(this.comboBox_room_SelectedIndexChanged);
-            this.comboBox_room.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.comboBox_KeyPress);
+            comboBox_room.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_room.FormattingEnabled = true;
+            comboBox_room.Location = new System.Drawing.Point(57, 50);
+            comboBox_room.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_room.Name = "comboBox_room";
+            comboBox_room.Size = new System.Drawing.Size(89, 23);
+            comboBox_room.TabIndex = 10;
+            comboBox_room.SelectedIndexChanged += comboBox_room_SelectedIndexChanged;
+            comboBox_room.KeyPress += comboBox_KeyPress;
             // 
             // comboBox_area
             // 
-            this.comboBox_area.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_area.FormattingEnabled = true;
-            this.comboBox_area.Location = new System.Drawing.Point(49, 18);
-            this.comboBox_area.Name = "comboBox_area";
-            this.comboBox_area.Size = new System.Drawing.Size(77, 21);
-            this.comboBox_area.TabIndex = 9;
-            this.comboBox_area.SelectedIndexChanged += new System.EventHandler(this.comboBox_area_SelectedIndexChanged);
+            comboBox_area.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_area.FormattingEnabled = true;
+            comboBox_area.Location = new System.Drawing.Point(57, 21);
+            comboBox_area.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_area.Name = "comboBox_area";
+            comboBox_area.Size = new System.Drawing.Size(89, 23);
+            comboBox_area.TabIndex = 9;
+            comboBox_area.SelectedIndexChanged += comboBox_area_SelectedIndexChanged;
             // 
             // label_room
             // 
-            this.label_room.AutoSize = true;
-            this.label_room.Location = new System.Drawing.Point(6, 46);
-            this.label_room.Name = "label_room";
-            this.label_room.Size = new System.Drawing.Size(38, 13);
-            this.label_room.TabIndex = 0;
-            this.label_room.Text = "Room:";
+            label_room.AutoSize = true;
+            label_room.Location = new System.Drawing.Point(7, 53);
+            label_room.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_room.Name = "label_room";
+            label_room.Size = new System.Drawing.Size(42, 15);
+            label_room.TabIndex = 0;
+            label_room.Text = "Room:";
             // 
             // label_area
             // 
-            this.label_area.AutoSize = true;
-            this.label_area.Location = new System.Drawing.Point(6, 21);
-            this.label_area.Name = "label_area";
-            this.label_area.Size = new System.Drawing.Size(32, 13);
-            this.label_area.TabIndex = 0;
-            this.label_area.Text = "Area:";
+            label_area.AutoSize = true;
+            label_area.Location = new System.Drawing.Point(7, 24);
+            label_area.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_area.Name = "label_area";
+            label_area.Size = new System.Drawing.Size(34, 15);
+            label_area.TabIndex = 0;
+            label_area.Text = "Area:";
             // 
             // groupBox_tileset
             // 
-            this.groupBox_tileset.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
-            this.groupBox_tileset.Controls.Add(this.comboBox_clipdata);
-            this.groupBox_tileset.Controls.Add(this.label_clipdata);
-            this.groupBox_tileset.Controls.Add(this.panel_tileset);
-            this.groupBox_tileset.Enabled = false;
-            this.groupBox_tileset.Location = new System.Drawing.Point(12, 160);
-            this.groupBox_tileset.MinimumSize = new System.Drawing.Size(287, 310);
-            this.groupBox_tileset.Name = "groupBox_tileset";
-            this.groupBox_tileset.Size = new System.Drawing.Size(287, 310);
-            this.groupBox_tileset.TabIndex = 4;
-            this.groupBox_tileset.TabStop = false;
-            this.groupBox_tileset.Text = "Tileset";
+            groupBox_tileset.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox_tileset.Controls.Add(comboBox_clipdata);
+            groupBox_tileset.Controls.Add(label_clipdata);
+            groupBox_tileset.Controls.Add(panel_tileset);
+            groupBox_tileset.Enabled = false;
+            groupBox_tileset.Location = new System.Drawing.Point(14, 185);
+            groupBox_tileset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_tileset.MinimumSize = new System.Drawing.Size(335, 358);
+            groupBox_tileset.Name = "groupBox_tileset";
+            groupBox_tileset.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_tileset.Size = new System.Drawing.Size(335, 358);
+            groupBox_tileset.TabIndex = 4;
+            groupBox_tileset.TabStop = false;
+            groupBox_tileset.Text = "Tileset";
             // 
             // comboBox_clipdata
             // 
-            this.comboBox_clipdata.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_clipdata.FormattingEnabled = true;
-            this.comboBox_clipdata.Location = new System.Drawing.Point(58, 19);
-            this.comboBox_clipdata.Name = "comboBox_clipdata";
-            this.comboBox_clipdata.Size = new System.Drawing.Size(222, 21);
-            this.comboBox_clipdata.TabIndex = 11;
+            comboBox_clipdata.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_clipdata.FormattingEnabled = true;
+            comboBox_clipdata.Location = new System.Drawing.Point(68, 22);
+            comboBox_clipdata.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_clipdata.Name = "comboBox_clipdata";
+            comboBox_clipdata.Size = new System.Drawing.Size(258, 23);
+            comboBox_clipdata.TabIndex = 11;
             // 
             // label_clipdata
             // 
-            this.label_clipdata.AutoSize = true;
-            this.label_clipdata.Location = new System.Drawing.Point(7, 23);
-            this.label_clipdata.Name = "label_clipdata";
-            this.label_clipdata.Size = new System.Drawing.Size(48, 13);
-            this.label_clipdata.TabIndex = 0;
-            this.label_clipdata.Text = "Clipdata:";
+            label_clipdata.AutoSize = true;
+            label_clipdata.Location = new System.Drawing.Point(8, 27);
+            label_clipdata.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_clipdata.Name = "label_clipdata";
+            label_clipdata.Size = new System.Drawing.Size(54, 15);
+            label_clipdata.TabIndex = 0;
+            label_clipdata.Text = "Clipdata:";
             // 
             // panel_tileset
             // 
-            this.panel_tileset.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
-            this.panel_tileset.AutoScroll = true;
-            this.panel_tileset.Controls.Add(this.tileView);
-            this.panel_tileset.Location = new System.Drawing.Point(7, 48);
-            this.panel_tileset.MinimumSize = new System.Drawing.Size(273, 256);
-            this.panel_tileset.Name = "panel_tileset";
-            this.panel_tileset.Size = new System.Drawing.Size(273, 256);
-            this.panel_tileset.TabIndex = 0;
+            panel_tileset.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            panel_tileset.AutoScroll = true;
+            panel_tileset.Controls.Add(tileView);
+            panel_tileset.Location = new System.Drawing.Point(8, 55);
+            panel_tileset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            panel_tileset.MinimumSize = new System.Drawing.Size(318, 295);
+            panel_tileset.Name = "panel_tileset";
+            panel_tileset.Size = new System.Drawing.Size(318, 295);
+            panel_tileset.TabIndex = 0;
             // 
             // tileView
             // 
-            this.tileView.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
-            this.tileView.Location = new System.Drawing.Point(0, 0);
-            this.tileView.Name = "tileView";
-            this.tileView.Size = new System.Drawing.Size(256, 256);
-            this.tileView.TabIndex = 0;
-            this.tileView.TabStop = false;
-            this.tileView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.tileView_MouseDown);
-            this.tileView.MouseLeave += new System.EventHandler(this.tileView_MouseLeave);
-            this.tileView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.tileView_MouseMove);
-            this.tileView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.tileView_MouseUp);
+            tileView.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
+            tileView.Location = new System.Drawing.Point(0, 0);
+            tileView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tileView.Name = "tileView";
+            tileView.Size = new System.Drawing.Size(299, 295);
+            tileView.TabIndex = 0;
+            tileView.TabStop = false;
+            tileView.MouseDown += tileView_MouseDown;
+            tileView.MouseLeave += tileView_MouseLeave;
+            tileView.MouseMove += tileView_MouseMove;
+            tileView.MouseUp += tileView_MouseUp;
             // 
             // groupBox_room
             // 
-            this.groupBox_room.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox_room.Controls.Add(this.panel_room);
-            this.groupBox_room.Enabled = false;
-            this.groupBox_room.Location = new System.Drawing.Point(305, 52);
-            this.groupBox_room.MinimumSize = new System.Drawing.Size(479, 418);
-            this.groupBox_room.Name = "groupBox_room";
-            this.groupBox_room.Size = new System.Drawing.Size(479, 418);
-            this.groupBox_room.TabIndex = 0;
-            this.groupBox_room.TabStop = false;
-            this.groupBox_room.Text = "Room";
+            groupBox_room.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            groupBox_room.Controls.Add(panel_room);
+            groupBox_room.Enabled = false;
+            groupBox_room.Location = new System.Drawing.Point(356, 60);
+            groupBox_room.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_room.MinimumSize = new System.Drawing.Size(559, 482);
+            groupBox_room.Name = "groupBox_room";
+            groupBox_room.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_room.Size = new System.Drawing.Size(559, 482);
+            groupBox_room.TabIndex = 0;
+            groupBox_room.TabStop = false;
+            groupBox_room.Text = "Room";
             // 
             // panel_room
             // 
-            this.panel_room.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.panel_room.AutoScroll = true;
-            this.panel_room.Controls.Add(this.roomView);
-            this.panel_room.Location = new System.Drawing.Point(7, 19);
-            this.panel_room.MinimumSize = new System.Drawing.Size(465, 393);
-            this.panel_room.Name = "panel_room";
-            this.panel_room.Size = new System.Drawing.Size(465, 393);
-            this.panel_room.TabIndex = 0;
+            panel_room.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            panel_room.AutoScroll = true;
+            panel_room.Controls.Add(roomView);
+            panel_room.Location = new System.Drawing.Point(8, 22);
+            panel_room.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            panel_room.MinimumSize = new System.Drawing.Size(542, 453);
+            panel_room.Name = "panel_room";
+            panel_room.Size = new System.Drawing.Size(542, 453);
+            panel_room.TabIndex = 0;
             // 
             // roomView
             // 
-            this.roomView.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.roomView.ContextMenuStrip = this.contextMenu;
-            this.roomView.Location = new System.Drawing.Point(0, 0);
-            this.roomView.Name = "roomView";
-            this.roomView.Size = new System.Drawing.Size(448, 376);
-            this.roomView.TabIndex = 0;
-            this.roomView.TabStop = false;
-            this.roomView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.roomView_MouseDown);
-            this.roomView.MouseLeave += new System.EventHandler(this.roomView_MouseLeave);
-            this.roomView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.roomView_MouseMove);
-            this.roomView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.roomView_MouseUp);
+            roomView.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            roomView.ContextMenuStrip = contextMenu;
+            roomView.Location = new System.Drawing.Point(0, 0);
+            roomView.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            roomView.Name = "roomView";
+            roomView.Size = new System.Drawing.Size(523, 434);
+            roomView.TabIndex = 0;
+            roomView.TabStop = false;
+            roomView.DoubleClick += roomView_DoubleClick;
+            roomView.MouseDown += roomView_MouseDown;
+            roomView.MouseLeave += roomView_MouseLeave;
+            roomView.MouseMove += roomView_MouseMove;
+            roomView.MouseUp += roomView_MouseUp;
             // 
             // contextMenu
             // 
-            this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.contextItem_addSprite,
-            this.contextItem_editSprite,
-            this.contextItem_removeSprite,
-            this.toolStripSeparator6,
-            this.contextItem_addDoor,
-            this.contextItem_editDoor,
-            this.contextItem_removeDoor,
-            this.toolStripSeparator12,
-            this.contextItem_addScroll,
-            this.contextItem_editScroll,
-            this.contextItem_removeScroll,
-            this.toolStripSeparator14,
-            this.contextItem_testRoom});
-            this.contextMenu.Name = "contextMenu";
-            this.contextMenu.Size = new System.Drawing.Size(158, 242);
-            this.contextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
+            contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { contextItem_addSprite, contextItem_editSprite, contextItem_removeSprite, toolStripSeparator6, contextItem_addDoor, contextItem_editDoor, contextItem_removeDoor, toolStripSeparator12, contextItem_addScroll, contextItem_editScroll, contextItem_removeScroll, toolStripSeparator14, contextItem_testRoom });
+            contextMenu.Name = "contextMenu";
+            contextMenu.Size = new System.Drawing.Size(158, 242);
+            contextMenu.Opening += contextMenu_Opening;
             // 
             // contextItem_addSprite
             // 
-            this.contextItem_addSprite.Name = "contextItem_addSprite";
-            this.contextItem_addSprite.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_addSprite.Text = "Add Sprite";
-            this.contextItem_addSprite.Click += new System.EventHandler(this.contextItem_addSprite_Click);
+            contextItem_addSprite.Name = "contextItem_addSprite";
+            contextItem_addSprite.Size = new System.Drawing.Size(157, 22);
+            contextItem_addSprite.Text = "Add Sprite";
+            contextItem_addSprite.Click += contextItem_addSprite_Click;
             // 
             // contextItem_editSprite
             // 
-            this.contextItem_editSprite.Name = "contextItem_editSprite";
-            this.contextItem_editSprite.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_editSprite.Text = "Edit Sprite";
-            this.contextItem_editSprite.Click += new System.EventHandler(this.contextItem_editSprite_Click);
+            contextItem_editSprite.Name = "contextItem_editSprite";
+            contextItem_editSprite.Size = new System.Drawing.Size(157, 22);
+            contextItem_editSprite.Text = "Edit Sprite";
+            contextItem_editSprite.Click += contextItem_editSprite_Click;
             // 
             // contextItem_removeSprite
             // 
-            this.contextItem_removeSprite.Name = "contextItem_removeSprite";
-            this.contextItem_removeSprite.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_removeSprite.Text = "Remove Sprite";
-            this.contextItem_removeSprite.Click += new System.EventHandler(this.contextItem_removeSprite_Click);
+            contextItem_removeSprite.Name = "contextItem_removeSprite";
+            contextItem_removeSprite.Size = new System.Drawing.Size(157, 22);
+            contextItem_removeSprite.Text = "Remove Sprite";
+            contextItem_removeSprite.Click += contextItem_removeSprite_Click;
             // 
             // toolStripSeparator6
             // 
-            this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(154, 6);
+            toolStripSeparator6.Name = "toolStripSeparator6";
+            toolStripSeparator6.Size = new System.Drawing.Size(154, 6);
             // 
             // contextItem_addDoor
             // 
-            this.contextItem_addDoor.Name = "contextItem_addDoor";
-            this.contextItem_addDoor.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_addDoor.Text = "Add Door";
-            this.contextItem_addDoor.Click += new System.EventHandler(this.contextItem_addDoor_Click);
+            contextItem_addDoor.Name = "contextItem_addDoor";
+            contextItem_addDoor.Size = new System.Drawing.Size(157, 22);
+            contextItem_addDoor.Text = "Add Door";
+            contextItem_addDoor.Click += contextItem_addDoor_Click;
             // 
             // contextItem_editDoor
             // 
-            this.contextItem_editDoor.Name = "contextItem_editDoor";
-            this.contextItem_editDoor.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_editDoor.Text = "Edit Door";
-            this.contextItem_editDoor.Click += new System.EventHandler(this.contextItem_editDoor_Click);
+            contextItem_editDoor.Name = "contextItem_editDoor";
+            contextItem_editDoor.Size = new System.Drawing.Size(157, 22);
+            contextItem_editDoor.Text = "Edit Door";
+            contextItem_editDoor.Click += contextItem_editDoor_Click;
             // 
             // contextItem_removeDoor
             // 
-            this.contextItem_removeDoor.Name = "contextItem_removeDoor";
-            this.contextItem_removeDoor.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_removeDoor.Text = "Remove Door";
-            this.contextItem_removeDoor.Click += new System.EventHandler(this.contextItem_removeDoor_Click);
+            contextItem_removeDoor.Name = "contextItem_removeDoor";
+            contextItem_removeDoor.Size = new System.Drawing.Size(157, 22);
+            contextItem_removeDoor.Text = "Remove Door";
+            contextItem_removeDoor.Click += contextItem_removeDoor_Click;
             // 
             // toolStripSeparator12
             // 
-            this.toolStripSeparator12.Name = "toolStripSeparator12";
-            this.toolStripSeparator12.Size = new System.Drawing.Size(154, 6);
+            toolStripSeparator12.Name = "toolStripSeparator12";
+            toolStripSeparator12.Size = new System.Drawing.Size(154, 6);
             // 
             // contextItem_addScroll
             // 
-            this.contextItem_addScroll.Name = "contextItem_addScroll";
-            this.contextItem_addScroll.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_addScroll.Text = "Add Scroll";
-            this.contextItem_addScroll.Click += new System.EventHandler(this.contextItem_addScroll_Click);
+            contextItem_addScroll.Name = "contextItem_addScroll";
+            contextItem_addScroll.Size = new System.Drawing.Size(157, 22);
+            contextItem_addScroll.Text = "Add Scroll";
+            contextItem_addScroll.Click += contextItem_addScroll_Click;
             // 
             // contextItem_editScroll
             // 
-            this.contextItem_editScroll.Name = "contextItem_editScroll";
-            this.contextItem_editScroll.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_editScroll.Text = "Edit Scroll";
-            this.contextItem_editScroll.Click += new System.EventHandler(this.contextItem_editScroll_Click);
+            contextItem_editScroll.Name = "contextItem_editScroll";
+            contextItem_editScroll.Size = new System.Drawing.Size(157, 22);
+            contextItem_editScroll.Text = "Edit Scroll";
+            contextItem_editScroll.Click += contextItem_editScroll_Click;
             // 
             // contextItem_removeScroll
             // 
-            this.contextItem_removeScroll.Name = "contextItem_removeScroll";
-            this.contextItem_removeScroll.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_removeScroll.Text = "Remove Scroll";
-            this.contextItem_removeScroll.Click += new System.EventHandler(this.contextItem_removeScroll_Click);
+            contextItem_removeScroll.Name = "contextItem_removeScroll";
+            contextItem_removeScroll.Size = new System.Drawing.Size(157, 22);
+            contextItem_removeScroll.Text = "Remove Scroll";
+            contextItem_removeScroll.Click += contextItem_removeScroll_Click;
             // 
             // toolStripSeparator14
             // 
-            this.toolStripSeparator14.Name = "toolStripSeparator14";
-            this.toolStripSeparator14.Size = new System.Drawing.Size(154, 6);
+            toolStripSeparator14.Name = "toolStripSeparator14";
+            toolStripSeparator14.Size = new System.Drawing.Size(154, 6);
             // 
             // contextItem_testRoom
             // 
-            this.contextItem_testRoom.Name = "contextItem_testRoom";
-            this.contextItem_testRoom.Size = new System.Drawing.Size(157, 22);
-            this.contextItem_testRoom.Text = "Test Room Here";
-            this.contextItem_testRoom.Click += new System.EventHandler(this.contextItem_testRoom_Click);
+            contextItem_testRoom.Name = "contextItem_testRoom";
+            contextItem_testRoom.Size = new System.Drawing.Size(157, 22);
+            contextItem_testRoom.Text = "Test Room Here";
+            contextItem_testRoom.Click += contextItem_testRoom_Click;
             // 
             // groupBox_viewBG
             // 
-            this.groupBox_viewBG.Controls.Add(this.checkBox_viewBG3);
-            this.groupBox_viewBG.Controls.Add(this.checkBox_viewBG2);
-            this.groupBox_viewBG.Controls.Add(this.checkBox_viewBG1);
-            this.groupBox_viewBG.Controls.Add(this.checkBox_viewBG0);
-            this.groupBox_viewBG.Enabled = false;
-            this.groupBox_viewBG.Location = new System.Drawing.Point(153, 52);
-            this.groupBox_viewBG.Name = "groupBox_viewBG";
-            this.groupBox_viewBG.Size = new System.Drawing.Size(70, 102);
-            this.groupBox_viewBG.TabIndex = 2;
-            this.groupBox_viewBG.TabStop = false;
-            this.groupBox_viewBG.Text = "View";
+            groupBox_viewBG.Controls.Add(checkBox_viewBG3);
+            groupBox_viewBG.Controls.Add(checkBox_viewBG2);
+            groupBox_viewBG.Controls.Add(checkBox_viewBG1);
+            groupBox_viewBG.Controls.Add(checkBox_viewBG0);
+            groupBox_viewBG.Enabled = false;
+            groupBox_viewBG.Location = new System.Drawing.Point(178, 60);
+            groupBox_viewBG.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_viewBG.Name = "groupBox_viewBG";
+            groupBox_viewBG.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_viewBG.Size = new System.Drawing.Size(82, 118);
+            groupBox_viewBG.TabIndex = 2;
+            groupBox_viewBG.TabStop = false;
+            groupBox_viewBG.Text = "View";
             // 
             // checkBox_viewBG3
             // 
-            this.checkBox_viewBG3.AutoSize = true;
-            this.checkBox_viewBG3.Location = new System.Drawing.Point(9, 77);
-            this.checkBox_viewBG3.Name = "checkBox_viewBG3";
-            this.checkBox_viewBG3.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_viewBG3.TabIndex = 3;
-            this.checkBox_viewBG3.Text = "BG 3";
-            this.checkBox_viewBG3.UseVisualStyleBackColor = true;
-            this.checkBox_viewBG3.CheckedChanged += new System.EventHandler(this.checkBox_viewBG3_CheckedChanged);
+            checkBox_viewBG3.AutoSize = true;
+            checkBox_viewBG3.Location = new System.Drawing.Point(10, 89);
+            checkBox_viewBG3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_viewBG3.Name = "checkBox_viewBG3";
+            checkBox_viewBG3.Size = new System.Drawing.Size(50, 19);
+            checkBox_viewBG3.TabIndex = 3;
+            checkBox_viewBG3.Text = "BG 3";
+            checkBox_viewBG3.UseVisualStyleBackColor = true;
+            checkBox_viewBG3.CheckedChanged += checkBox_viewBG3_CheckedChanged;
             // 
             // checkBox_viewBG2
             // 
-            this.checkBox_viewBG2.AutoSize = true;
-            this.checkBox_viewBG2.Location = new System.Drawing.Point(9, 57);
-            this.checkBox_viewBG2.Name = "checkBox_viewBG2";
-            this.checkBox_viewBG2.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_viewBG2.TabIndex = 2;
-            this.checkBox_viewBG2.Text = "BG 2";
-            this.checkBox_viewBG2.UseVisualStyleBackColor = true;
-            this.checkBox_viewBG2.CheckedChanged += new System.EventHandler(this.checkBox_viewBG2_CheckedChanged);
+            checkBox_viewBG2.AutoSize = true;
+            checkBox_viewBG2.Location = new System.Drawing.Point(10, 66);
+            checkBox_viewBG2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_viewBG2.Name = "checkBox_viewBG2";
+            checkBox_viewBG2.Size = new System.Drawing.Size(50, 19);
+            checkBox_viewBG2.TabIndex = 2;
+            checkBox_viewBG2.Text = "BG 2";
+            checkBox_viewBG2.UseVisualStyleBackColor = true;
+            checkBox_viewBG2.CheckedChanged += checkBox_viewBG2_CheckedChanged;
             // 
             // checkBox_viewBG1
             // 
-            this.checkBox_viewBG1.AutoSize = true;
-            this.checkBox_viewBG1.Location = new System.Drawing.Point(9, 37);
-            this.checkBox_viewBG1.Name = "checkBox_viewBG1";
-            this.checkBox_viewBG1.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_viewBG1.TabIndex = 1;
-            this.checkBox_viewBG1.Text = "BG 1";
-            this.checkBox_viewBG1.UseVisualStyleBackColor = true;
-            this.checkBox_viewBG1.CheckedChanged += new System.EventHandler(this.checkBox_viewBG1_CheckedChanged);
+            checkBox_viewBG1.AutoSize = true;
+            checkBox_viewBG1.Location = new System.Drawing.Point(10, 43);
+            checkBox_viewBG1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_viewBG1.Name = "checkBox_viewBG1";
+            checkBox_viewBG1.Size = new System.Drawing.Size(50, 19);
+            checkBox_viewBG1.TabIndex = 1;
+            checkBox_viewBG1.Text = "BG 1";
+            checkBox_viewBG1.UseVisualStyleBackColor = true;
+            checkBox_viewBG1.CheckedChanged += checkBox_viewBG1_CheckedChanged;
             // 
             // checkBox_viewBG0
             // 
-            this.checkBox_viewBG0.AutoSize = true;
-            this.checkBox_viewBG0.Location = new System.Drawing.Point(9, 17);
-            this.checkBox_viewBG0.Name = "checkBox_viewBG0";
-            this.checkBox_viewBG0.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_viewBG0.TabIndex = 0;
-            this.checkBox_viewBG0.Text = "BG 0";
-            this.checkBox_viewBG0.UseVisualStyleBackColor = true;
-            this.checkBox_viewBG0.CheckedChanged += new System.EventHandler(this.checkBox_viewBG0_CheckedChanged);
+            checkBox_viewBG0.AutoSize = true;
+            checkBox_viewBG0.Location = new System.Drawing.Point(10, 20);
+            checkBox_viewBG0.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_viewBG0.Name = "checkBox_viewBG0";
+            checkBox_viewBG0.Size = new System.Drawing.Size(50, 19);
+            checkBox_viewBG0.TabIndex = 0;
+            checkBox_viewBG0.Text = "BG 0";
+            checkBox_viewBG0.UseVisualStyleBackColor = true;
+            checkBox_viewBG0.CheckedChanged += checkBox_viewBG0_CheckedChanged;
             // 
             // groupBox_editBG
             // 
-            this.groupBox_editBG.Controls.Add(this.checkBox_editCLP);
-            this.groupBox_editBG.Controls.Add(this.checkBox_editBG2);
-            this.groupBox_editBG.Controls.Add(this.checkBox_editBG1);
-            this.groupBox_editBG.Controls.Add(this.checkBox_editBG0);
-            this.groupBox_editBG.Enabled = false;
-            this.groupBox_editBG.Location = new System.Drawing.Point(229, 52);
-            this.groupBox_editBG.Name = "groupBox_editBG";
-            this.groupBox_editBG.Size = new System.Drawing.Size(70, 102);
-            this.groupBox_editBG.TabIndex = 3;
-            this.groupBox_editBG.TabStop = false;
-            this.groupBox_editBG.Tag = "";
-            this.groupBox_editBG.Text = "Edit";
+            groupBox_editBG.Controls.Add(checkBox_editCLP);
+            groupBox_editBG.Controls.Add(checkBox_editBG2);
+            groupBox_editBG.Controls.Add(checkBox_editBG1);
+            groupBox_editBG.Controls.Add(checkBox_editBG0);
+            groupBox_editBG.Enabled = false;
+            groupBox_editBG.Location = new System.Drawing.Point(267, 60);
+            groupBox_editBG.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_editBG.Name = "groupBox_editBG";
+            groupBox_editBG.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_editBG.Size = new System.Drawing.Size(82, 118);
+            groupBox_editBG.TabIndex = 3;
+            groupBox_editBG.TabStop = false;
+            groupBox_editBG.Tag = "";
+            groupBox_editBG.Text = "Edit";
             // 
             // checkBox_editCLP
             // 
-            this.checkBox_editCLP.AutoSize = true;
-            this.checkBox_editCLP.Location = new System.Drawing.Point(9, 77);
-            this.checkBox_editCLP.Name = "checkBox_editCLP";
-            this.checkBox_editCLP.Size = new System.Drawing.Size(43, 17);
-            this.checkBox_editCLP.TabIndex = 3;
-            this.checkBox_editCLP.Text = "Clip";
-            this.checkBox_editCLP.UseVisualStyleBackColor = true;
-            this.checkBox_editCLP.CheckedChanged += new System.EventHandler(this.checkBox_editCLP_CheckedChanged);
+            checkBox_editCLP.AutoSize = true;
+            checkBox_editCLP.Location = new System.Drawing.Point(10, 89);
+            checkBox_editCLP.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_editCLP.Name = "checkBox_editCLP";
+            checkBox_editCLP.Size = new System.Drawing.Size(47, 19);
+            checkBox_editCLP.TabIndex = 3;
+            checkBox_editCLP.Text = "Clip";
+            checkBox_editCLP.UseVisualStyleBackColor = true;
+            checkBox_editCLP.CheckedChanged += checkBox_editCLP_CheckedChanged;
             // 
             // checkBox_editBG2
             // 
-            this.checkBox_editBG2.AutoSize = true;
-            this.checkBox_editBG2.Location = new System.Drawing.Point(9, 57);
-            this.checkBox_editBG2.Name = "checkBox_editBG2";
-            this.checkBox_editBG2.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_editBG2.TabIndex = 2;
-            this.checkBox_editBG2.Text = "BG 2";
-            this.checkBox_editBG2.UseVisualStyleBackColor = true;
-            this.checkBox_editBG2.CheckedChanged += new System.EventHandler(this.checkBox_editBG2_CheckedChanged);
+            checkBox_editBG2.AutoSize = true;
+            checkBox_editBG2.Location = new System.Drawing.Point(10, 66);
+            checkBox_editBG2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_editBG2.Name = "checkBox_editBG2";
+            checkBox_editBG2.Size = new System.Drawing.Size(50, 19);
+            checkBox_editBG2.TabIndex = 2;
+            checkBox_editBG2.Text = "BG 2";
+            checkBox_editBG2.UseVisualStyleBackColor = true;
+            checkBox_editBG2.CheckedChanged += checkBox_editBG2_CheckedChanged;
             // 
             // checkBox_editBG1
             // 
-            this.checkBox_editBG1.AutoSize = true;
-            this.checkBox_editBG1.Location = new System.Drawing.Point(9, 37);
-            this.checkBox_editBG1.Name = "checkBox_editBG1";
-            this.checkBox_editBG1.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_editBG1.TabIndex = 1;
-            this.checkBox_editBG1.Text = "BG 1";
-            this.checkBox_editBG1.UseVisualStyleBackColor = true;
-            this.checkBox_editBG1.CheckedChanged += new System.EventHandler(this.checkBox_editBG1_CheckedChanged);
+            checkBox_editBG1.AutoSize = true;
+            checkBox_editBG1.Location = new System.Drawing.Point(10, 43);
+            checkBox_editBG1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_editBG1.Name = "checkBox_editBG1";
+            checkBox_editBG1.Size = new System.Drawing.Size(50, 19);
+            checkBox_editBG1.TabIndex = 1;
+            checkBox_editBG1.Text = "BG 1";
+            checkBox_editBG1.UseVisualStyleBackColor = true;
+            checkBox_editBG1.CheckedChanged += checkBox_editBG1_CheckedChanged;
             // 
             // checkBox_editBG0
             // 
-            this.checkBox_editBG0.AutoSize = true;
-            this.checkBox_editBG0.Location = new System.Drawing.Point(9, 17);
-            this.checkBox_editBG0.Name = "checkBox_editBG0";
-            this.checkBox_editBG0.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_editBG0.TabIndex = 0;
-            this.checkBox_editBG0.Text = "BG 0";
-            this.checkBox_editBG0.UseVisualStyleBackColor = true;
-            this.checkBox_editBG0.CheckedChanged += new System.EventHandler(this.checkBox_editBG0_CheckedChanged);
+            checkBox_editBG0.AutoSize = true;
+            checkBox_editBG0.Location = new System.Drawing.Point(10, 20);
+            checkBox_editBG0.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_editBG0.Name = "checkBox_editBG0";
+            checkBox_editBG0.Size = new System.Drawing.Size(50, 19);
+            checkBox_editBG0.TabIndex = 0;
+            checkBox_editBG0.Text = "BG 0";
+            checkBox_editBG0.UseVisualStyleBackColor = true;
+            checkBox_editBG0.CheckedChanged += checkBox_editBG0_CheckedChanged;
             // 
             // statusStrip
             // 
-            this.statusStrip.Enabled = false;
-            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.statusLabel_coor,
-            this.statusLabel_sel,
-            this.statusLabel_clip});
-            this.statusStrip.Location = new System.Drawing.Point(0, 473);
-            this.statusStrip.Name = "statusStrip";
-            this.statusStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
-            this.statusStrip.ShowItemToolTips = true;
-            this.statusStrip.Size = new System.Drawing.Size(796, 24);
-            this.statusStrip.TabIndex = 0;
+            statusStrip.Enabled = false;
+            statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { statusLabel_coor, statusLabel_sel, statusLabel_clip });
+            statusStrip.Location = new System.Drawing.Point(0, 549);
+            statusStrip.Name = "statusStrip";
+            statusStrip.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
+            statusStrip.ShowItemToolTips = true;
+            statusStrip.Size = new System.Drawing.Size(929, 24);
+            statusStrip.TabIndex = 0;
             // 
             // statusLabel_coor
             // 
-            this.statusLabel_coor.AutoSize = false;
-            this.statusLabel_coor.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-            this.statusLabel_coor.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
-            this.statusLabel_coor.Name = "statusLabel_coor";
-            this.statusLabel_coor.Size = new System.Drawing.Size(70, 19);
-            this.statusLabel_coor.Text = "(0, 0)";
-            this.statusLabel_coor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.statusLabel_coor.ToolTipText = "Coordinates";
+            statusLabel_coor.AutoSize = false;
+            statusLabel_coor.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+            statusLabel_coor.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
+            statusLabel_coor.Name = "statusLabel_coor";
+            statusLabel_coor.Size = new System.Drawing.Size(70, 19);
+            statusLabel_coor.Text = "(0, 0)";
+            statusLabel_coor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusLabel_coor.ToolTipText = "Coordinates";
             // 
             // statusLabel_sel
             // 
-            this.statusLabel_sel.AutoSize = false;
-            this.statusLabel_sel.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
-            this.statusLabel_sel.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
-            this.statusLabel_sel.Name = "statusLabel_sel";
-            this.statusLabel_sel.Size = new System.Drawing.Size(70, 19);
-            this.statusLabel_sel.Text = "0 x 0";
-            this.statusLabel_sel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.statusLabel_sel.ToolTipText = "Selection size";
+            statusLabel_sel.AutoSize = false;
+            statusLabel_sel.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Right;
+            statusLabel_sel.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
+            statusLabel_sel.Name = "statusLabel_sel";
+            statusLabel_sel.Size = new System.Drawing.Size(70, 19);
+            statusLabel_sel.Text = "0 x 0";
+            statusLabel_sel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusLabel_sel.ToolTipText = "Selection size";
             // 
             // statusLabel_clip
             // 
-            this.statusLabel_clip.Name = "statusLabel_clip";
-            this.statusLabel_clip.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.statusLabel_clip.Size = new System.Drawing.Size(10, 19);
-            this.statusLabel_clip.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.statusLabel_clip.ToolTipText = "Clipdata";
+            statusLabel_clip.Name = "statusLabel_clip";
+            statusLabel_clip.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
+            statusLabel_clip.Size = new System.Drawing.Size(10, 19);
+            statusLabel_clip.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            statusLabel_clip.ToolTipText = "Clipdata";
             // 
             // label_spriteset
             // 
-            this.label_spriteset.AutoSize = true;
-            this.label_spriteset.Enabled = false;
-            this.label_spriteset.Location = new System.Drawing.Point(12, 135);
-            this.label_spriteset.Name = "label_spriteset";
-            this.label_spriteset.Size = new System.Drawing.Size(51, 13);
-            this.label_spriteset.TabIndex = 8;
-            this.label_spriteset.Text = "Spriteset:";
+            label_spriteset.AutoSize = true;
+            label_spriteset.Enabled = false;
+            label_spriteset.Location = new System.Drawing.Point(14, 156);
+            label_spriteset.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_spriteset.Name = "label_spriteset";
+            label_spriteset.Size = new System.Drawing.Size(55, 15);
+            label_spriteset.TabIndex = 8;
+            label_spriteset.Text = "Spriteset:";
             // 
             // toolStrip
             // 
-            this.toolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStrip_open,
-            this.toolStrip_save,
-            this.toolStripSeparator9,
-            this.toolStrip_undo,
-            this.toolStrip_redo,
-            this.toolStripSeparator10,
-            this.toolStrip_editBGs,
-            this.toolStrip_editObjects,
-            this.toolStripSeparator15,
-            this.toolStrip_viewSprites,
-            this.toolStrip_outlineSprites,
-            this.toolStrip_outlineDoors,
-            this.toolStrip_outlineScrolls,
-            this.toolStripSeparator16,
-            this.toolStrip_header,
-            this.toolStrip_tileset,
-            this.toolStrip_graphics,
-            this.toolStrip_palette,
-            this.toolStrip_tileTable,
-            this.toolStrip_animation,
-            this.toolStrip_sprite,
-            this.toolStrip_spriteset,
-            this.toolStrip_connection,
-            this.toolStrip_minimap,
-            this.toolStrip_text,
-            this.toolStrip_demoEditor,
-            this.toolStrip_physics,
-            this.toolStrip_weapon,
-            this.toolStripSeparator11,
-            this.toolStrip_options,
-            this.toolStrip_test,
-            this.toolStrip_tileBuilder,
-            this.toolStrip_add,
-            this.toolStrip_patches});
-            this.toolStrip.Location = new System.Drawing.Point(0, 24);
-            this.toolStrip.Name = "toolStrip";
-            this.toolStrip.Padding = new System.Windows.Forms.Padding(3, 0, 1, 0);
-            this.toolStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStrip.Size = new System.Drawing.Size(796, 25);
-            this.toolStrip.TabIndex = 0;
+            toolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStrip_open, toolStrip_save, toolStripSeparator9, toolStrip_undo, toolStrip_redo, toolStripSeparator10, toolStrip_editBGs, toolStrip_editObjects, toolStripSeparator15, toolStrip_viewSprites, toolStrip_outlineSprites, toolStrip_outlineDoors, toolStrip_outlineScrolls, toolStripSeparator16, toolStrip_header, toolStrip_tileset, toolStrip_graphics, toolStrip_palette, toolStrip_tileTable, toolStrip_animation, toolStrip_sprite, toolStrip_spriteset, toolStrip_connection, toolStrip_minimap, toolStrip_text, toolStrip_demoEditor, toolStrip_physics, toolStrip_weapon, toolStripSeparator11, toolStrip_options, toolStrip_test, toolStrip_tileBuilder, toolStrip_add, toolStrip_patches });
+            toolStrip.Location = new System.Drawing.Point(0, 24);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new System.Windows.Forms.Padding(4, 0, 1, 0);
+            toolStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            toolStrip.Size = new System.Drawing.Size(929, 25);
+            toolStrip.TabIndex = 0;
             // 
             // toolStrip_open
             // 
-            this.toolStrip_open.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_open.Image = global::mage.Properties.Resources.toolbar_open;
-            this.toolStrip_open.Name = "toolStrip_open";
-            this.toolStrip_open.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_open.Text = "Open ROM";
-            this.toolStrip_open.Click += new System.EventHandler(this.menuItem_openROM_Click);
+            toolStrip_open.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_open.Image = Properties.Resources.toolbar_open;
+            toolStrip_open.Name = "toolStrip_open";
+            toolStrip_open.Size = new System.Drawing.Size(23, 22);
+            toolStrip_open.Text = "Open ROM";
+            toolStrip_open.Click += menuItem_openROM_Click;
             // 
             // toolStrip_save
             // 
-            this.toolStrip_save.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_save.Enabled = false;
-            this.toolStrip_save.Image = global::mage.Properties.Resources.toolbar_save;
-            this.toolStrip_save.Name = "toolStrip_save";
-            this.toolStrip_save.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_save.Text = "Save ROM";
-            this.toolStrip_save.Click += new System.EventHandler(this.menuItem_saveROM_Click);
+            toolStrip_save.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_save.Enabled = false;
+            toolStrip_save.Image = Properties.Resources.toolbar_save;
+            toolStrip_save.Name = "toolStrip_save";
+            toolStrip_save.Size = new System.Drawing.Size(23, 22);
+            toolStrip_save.Text = "Save ROM";
+            toolStrip_save.Click += menuItem_saveROM_Click;
             // 
             // toolStripSeparator9
             // 
-            this.toolStripSeparator9.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator9.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            toolStripSeparator9.Name = "toolStripSeparator9";
+            toolStripSeparator9.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStrip_undo
             // 
-            this.toolStrip_undo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_undo.Enabled = false;
-            this.toolStrip_undo.Image = global::mage.Properties.Resources.toolbar_undo;
-            this.toolStrip_undo.Name = "toolStrip_undo";
-            this.toolStrip_undo.Size = new System.Drawing.Size(32, 22);
-            this.toolStrip_undo.ButtonClick += new System.EventHandler(this.menuItem_undo_Click);
-            this.toolStrip_undo.DropDownOpening += new System.EventHandler(this.toolStrip_undo_DropDownOpening);
-            this.toolStrip_undo.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.toolStrip_undo_DropDownItemClicked);
+            toolStrip_undo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_undo.Enabled = false;
+            toolStrip_undo.Image = Properties.Resources.toolbar_undo;
+            toolStrip_undo.Name = "toolStrip_undo";
+            toolStrip_undo.Size = new System.Drawing.Size(32, 22);
+            toolStrip_undo.ButtonClick += menuItem_undo_Click;
+            toolStrip_undo.DropDownOpening += toolStrip_undo_DropDownOpening;
+            toolStrip_undo.DropDownItemClicked += toolStrip_undo_DropDownItemClicked;
             // 
             // toolStrip_redo
             // 
-            this.toolStrip_redo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_redo.Enabled = false;
-            this.toolStrip_redo.Image = global::mage.Properties.Resources.toolbar_redo;
-            this.toolStrip_redo.Name = "toolStrip_redo";
-            this.toolStrip_redo.Size = new System.Drawing.Size(32, 22);
-            this.toolStrip_redo.ButtonClick += new System.EventHandler(this.menuItem_redo_Click);
-            this.toolStrip_redo.DropDownOpening += new System.EventHandler(this.toolStrip_redo_DropDownOpening);
-            this.toolStrip_redo.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.toolStrip_redo_DropDownItemClicked);
+            toolStrip_redo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_redo.Enabled = false;
+            toolStrip_redo.Image = Properties.Resources.toolbar_redo;
+            toolStrip_redo.Name = "toolStrip_redo";
+            toolStrip_redo.Size = new System.Drawing.Size(32, 22);
+            toolStrip_redo.ButtonClick += menuItem_redo_Click;
+            toolStrip_redo.DropDownOpening += toolStrip_redo_DropDownOpening;
+            toolStrip_redo.DropDownItemClicked += toolStrip_redo_DropDownItemClicked;
             // 
             // toolStripSeparator10
             // 
-            this.toolStripSeparator10.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator10.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            toolStripSeparator10.Name = "toolStripSeparator10";
+            toolStripSeparator10.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStrip_editBGs
             // 
-            this.toolStrip_editBGs.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_editBGs.Enabled = false;
-            this.toolStrip_editBGs.Image = global::mage.Properties.Resources.shortcut_speed;
-            this.toolStrip_editBGs.Name = "toolStrip_editBGs";
-            this.toolStrip_editBGs.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_editBGs.Text = "BG editing mode";
-            this.toolStrip_editBGs.Click += new System.EventHandler(this.menuItem_editMode_Click);
+            toolStrip_editBGs.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_editBGs.Enabled = false;
+            toolStrip_editBGs.Image = Properties.Resources.shortcut_speed;
+            toolStrip_editBGs.Name = "toolStrip_editBGs";
+            toolStrip_editBGs.Size = new System.Drawing.Size(23, 22);
+            toolStrip_editBGs.Text = "BG editing mode";
+            toolStrip_editBGs.Click += menuItem_editMode_Click;
             // 
             // toolStrip_editObjects
             // 
-            this.toolStrip_editObjects.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_editObjects.Enabled = false;
-            this.toolStrip_editObjects.Image = global::mage.Properties.Resources.toolbar_edit_objects;
-            this.toolStrip_editObjects.Name = "toolStrip_editObjects";
-            this.toolStrip_editObjects.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_editObjects.Text = "Object editing mode";
-            this.toolStrip_editObjects.Click += new System.EventHandler(this.menuItem_editMode_Click);
+            toolStrip_editObjects.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_editObjects.Enabled = false;
+            toolStrip_editObjects.Image = Properties.Resources.toolbar_edit_objects;
+            toolStrip_editObjects.Name = "toolStrip_editObjects";
+            toolStrip_editObjects.Size = new System.Drawing.Size(23, 22);
+            toolStrip_editObjects.Text = "Object editing mode";
+            toolStrip_editObjects.Click += menuItem_editMode_Click;
             // 
             // toolStripSeparator15
             // 
-            this.toolStripSeparator15.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.toolStripSeparator15.Name = "toolStripSeparator15";
-            this.toolStripSeparator15.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator15.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            toolStripSeparator15.Name = "toolStripSeparator15";
+            toolStripSeparator15.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStrip_viewSprites
             // 
-            this.toolStrip_viewSprites.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_viewSprites.Enabled = false;
-            this.toolStrip_viewSprites.Image = global::mage.Properties.Resources.toolbar_view_sprites;
-            this.toolStrip_viewSprites.Name = "toolStrip_viewSprites";
-            this.toolStrip_viewSprites.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_viewSprites.Text = "View sprites";
-            this.toolStrip_viewSprites.Click += new System.EventHandler(this.menuItem_viewSprites_Click);
+            toolStrip_viewSprites.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_viewSprites.Enabled = false;
+            toolStrip_viewSprites.Image = Properties.Resources.toolbar_view_sprites;
+            toolStrip_viewSprites.Name = "toolStrip_viewSprites";
+            toolStrip_viewSprites.Size = new System.Drawing.Size(23, 22);
+            toolStrip_viewSprites.Text = "View sprites";
+            toolStrip_viewSprites.Click += menuItem_viewSprites_Click;
             // 
             // toolStrip_outlineSprites
             // 
-            this.toolStrip_outlineSprites.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_outlineSprites.Enabled = false;
-            this.toolStrip_outlineSprites.Image = global::mage.Properties.Resources.toolbar_outline_sprites;
-            this.toolStrip_outlineSprites.Name = "toolStrip_outlineSprites";
-            this.toolStrip_outlineSprites.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_outlineSprites.Text = "Outline sprites";
-            this.toolStrip_outlineSprites.Click += new System.EventHandler(this.menuItem_outlineSprites_Click);
+            toolStrip_outlineSprites.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_outlineSprites.Enabled = false;
+            toolStrip_outlineSprites.Image = Properties.Resources.toolbar_outline_sprites;
+            toolStrip_outlineSprites.Name = "toolStrip_outlineSprites";
+            toolStrip_outlineSprites.Size = new System.Drawing.Size(23, 22);
+            toolStrip_outlineSprites.Text = "Outline sprites";
+            toolStrip_outlineSprites.Click += menuItem_outlineSprites_Click;
             // 
             // toolStrip_outlineDoors
             // 
-            this.toolStrip_outlineDoors.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_outlineDoors.Enabled = false;
-            this.toolStrip_outlineDoors.Image = global::mage.Properties.Resources.toolbar_outline_doors;
-            this.toolStrip_outlineDoors.Name = "toolStrip_outlineDoors";
-            this.toolStrip_outlineDoors.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_outlineDoors.Text = "Outline doors";
-            this.toolStrip_outlineDoors.Click += new System.EventHandler(this.menuItem_outlineDoors_Click);
+            toolStrip_outlineDoors.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_outlineDoors.Enabled = false;
+            toolStrip_outlineDoors.Image = Properties.Resources.toolbar_outline_doors;
+            toolStrip_outlineDoors.Name = "toolStrip_outlineDoors";
+            toolStrip_outlineDoors.Size = new System.Drawing.Size(23, 22);
+            toolStrip_outlineDoors.Text = "Outline doors";
+            toolStrip_outlineDoors.Click += menuItem_outlineDoors_Click;
             // 
             // toolStrip_outlineScrolls
             // 
-            this.toolStrip_outlineScrolls.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_outlineScrolls.Enabled = false;
-            this.toolStrip_outlineScrolls.Image = global::mage.Properties.Resources.toolbar_outline_scrolls;
-            this.toolStrip_outlineScrolls.Name = "toolStrip_outlineScrolls";
-            this.toolStrip_outlineScrolls.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_outlineScrolls.Text = "Outline scrolls";
-            this.toolStrip_outlineScrolls.Click += new System.EventHandler(this.menuItem_outlineScrolls_Click);
+            toolStrip_outlineScrolls.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_outlineScrolls.Enabled = false;
+            toolStrip_outlineScrolls.Image = Properties.Resources.toolbar_outline_scrolls;
+            toolStrip_outlineScrolls.Name = "toolStrip_outlineScrolls";
+            toolStrip_outlineScrolls.Size = new System.Drawing.Size(23, 22);
+            toolStrip_outlineScrolls.Text = "Outline scrolls";
+            toolStrip_outlineScrolls.Click += menuItem_outlineScrolls_Click;
             // 
             // toolStripSeparator16
             // 
-            this.toolStripSeparator16.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.toolStripSeparator16.Name = "toolStripSeparator16";
-            this.toolStripSeparator16.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator16.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            toolStripSeparator16.Name = "toolStripSeparator16";
+            toolStripSeparator16.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStrip_header
             // 
-            this.toolStrip_header.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_header.Enabled = false;
-            this.toolStrip_header.Image = global::mage.Properties.Resources.toolbar_header;
-            this.toolStrip_header.Name = "toolStrip_header";
-            this.toolStrip_header.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_header.Text = "Header Editor";
-            this.toolStrip_header.Click += new System.EventHandler(this.menuItem_headerEditor_Click);
+            toolStrip_header.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_header.Enabled = false;
+            toolStrip_header.Image = Properties.Resources.toolbar_header;
+            toolStrip_header.Name = "toolStrip_header";
+            toolStrip_header.Size = new System.Drawing.Size(23, 22);
+            toolStrip_header.Text = "Header Editor";
+            toolStrip_header.Click += menuItem_headerEditor_Click;
             // 
             // toolStrip_tileset
             // 
-            this.toolStrip_tileset.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_tileset.Enabled = false;
-            this.toolStrip_tileset.Image = global::mage.Properties.Resources.shortcut_screw;
-            this.toolStrip_tileset.Name = "toolStrip_tileset";
-            this.toolStrip_tileset.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_tileset.Text = "Tileset Editor";
-            this.toolStrip_tileset.Click += new System.EventHandler(this.menuItem_tilesetEditor_Click);
+            toolStrip_tileset.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_tileset.Enabled = false;
+            toolStrip_tileset.Image = Properties.Resources.shortcut_screw;
+            toolStrip_tileset.Name = "toolStrip_tileset";
+            toolStrip_tileset.Size = new System.Drawing.Size(23, 22);
+            toolStrip_tileset.Text = "Tileset Editor";
+            toolStrip_tileset.Click += menuItem_tilesetEditor_Click;
             // 
             // toolStrip_graphics
             // 
-            this.toolStrip_graphics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_graphics.Enabled = false;
-            this.toolStrip_graphics.Image = global::mage.Properties.Resources.toolbar_graphics;
-            this.toolStrip_graphics.Name = "toolStrip_graphics";
-            this.toolStrip_graphics.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_graphics.Text = "Graphics Editor";
-            this.toolStrip_graphics.Click += new System.EventHandler(this.menuItem_graphicsEditor_Click);
+            toolStrip_graphics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_graphics.Enabled = false;
+            toolStrip_graphics.Image = Properties.Resources.toolbar_graphics;
+            toolStrip_graphics.Name = "toolStrip_graphics";
+            toolStrip_graphics.Size = new System.Drawing.Size(23, 22);
+            toolStrip_graphics.Text = "Graphics Editor";
+            toolStrip_graphics.Click += menuItem_graphicsEditor_Click;
             // 
             // toolStrip_palette
             // 
-            this.toolStrip_palette.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_palette.Enabled = false;
-            this.toolStrip_palette.Image = global::mage.Properties.Resources.toolbar_palette;
-            this.toolStrip_palette.Name = "toolStrip_palette";
-            this.toolStrip_palette.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_palette.Text = "Palette Editor";
-            this.toolStrip_palette.Click += new System.EventHandler(this.menuItem_paletteEditor_Click);
+            toolStrip_palette.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_palette.Enabled = false;
+            toolStrip_palette.Image = Properties.Resources.toolbar_palette;
+            toolStrip_palette.Name = "toolStrip_palette";
+            toolStrip_palette.Size = new System.Drawing.Size(23, 22);
+            toolStrip_palette.Text = "Palette Editor";
+            toolStrip_palette.Click += menuItem_paletteEditor_Click;
             // 
             // toolStrip_tileTable
             // 
-            this.toolStrip_tileTable.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_tileTable.Enabled = false;
-            this.toolStrip_tileTable.Image = global::mage.Properties.Resources.toolbar_tile_table;
-            this.toolStrip_tileTable.Name = "toolStrip_tileTable";
-            this.toolStrip_tileTable.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_tileTable.Text = "Tile Table Editor";
-            this.toolStrip_tileTable.Click += new System.EventHandler(this.menuItem_tileTableEditor_Click);
+            toolStrip_tileTable.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_tileTable.Enabled = false;
+            toolStrip_tileTable.Image = Properties.Resources.toolbar_tile_table;
+            toolStrip_tileTable.Name = "toolStrip_tileTable";
+            toolStrip_tileTable.Size = new System.Drawing.Size(23, 22);
+            toolStrip_tileTable.Text = "Tile Table Editor";
+            toolStrip_tileTable.Click += menuItem_tileTableEditor_Click;
             // 
             // toolStrip_animation
             // 
-            this.toolStrip_animation.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_animation.Enabled = false;
-            this.toolStrip_animation.Image = global::mage.Properties.Resources.toolbar_animation;
-            this.toolStrip_animation.Name = "toolStrip_animation";
-            this.toolStrip_animation.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_animation.Text = "Animation Editor";
-            this.toolStrip_animation.Click += new System.EventHandler(this.menuItem_animationEditor_Click);
+            toolStrip_animation.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_animation.Enabled = false;
+            toolStrip_animation.Image = Properties.Resources.toolbar_animation;
+            toolStrip_animation.Name = "toolStrip_animation";
+            toolStrip_animation.Size = new System.Drawing.Size(23, 22);
+            toolStrip_animation.Text = "Animation Editor";
+            toolStrip_animation.Click += menuItem_animationEditor_Click;
             // 
             // toolStrip_sprite
             // 
-            this.toolStrip_sprite.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_sprite.Enabled = false;
-            this.toolStrip_sprite.Image = global::mage.Properties.Resources.toolbar_sprite;
-            this.toolStrip_sprite.Name = "toolStrip_sprite";
-            this.toolStrip_sprite.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_sprite.Text = "Sprite Editor";
-            this.toolStrip_sprite.Click += new System.EventHandler(this.menuItem_spriteEditor_Click);
+            toolStrip_sprite.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_sprite.Enabled = false;
+            toolStrip_sprite.Image = Properties.Resources.toolbar_sprite;
+            toolStrip_sprite.Name = "toolStrip_sprite";
+            toolStrip_sprite.Size = new System.Drawing.Size(23, 22);
+            toolStrip_sprite.Text = "Sprite Editor";
+            toolStrip_sprite.Click += menuItem_spriteEditor_Click;
             // 
             // toolStrip_spriteset
             // 
-            this.toolStrip_spriteset.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_spriteset.Enabled = false;
-            this.toolStrip_spriteset.Image = global::mage.Properties.Resources.toolbar_spriteset;
-            this.toolStrip_spriteset.Name = "toolStrip_spriteset";
-            this.toolStrip_spriteset.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_spriteset.Text = "Spriteset Editor";
-            this.toolStrip_spriteset.Click += new System.EventHandler(this.menuItem_spritesetEditor_Click);
+            toolStrip_spriteset.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_spriteset.Enabled = false;
+            toolStrip_spriteset.Image = Properties.Resources.toolbar_spriteset;
+            toolStrip_spriteset.Name = "toolStrip_spriteset";
+            toolStrip_spriteset.Size = new System.Drawing.Size(23, 22);
+            toolStrip_spriteset.Text = "Spriteset Editor";
+            toolStrip_spriteset.Click += menuItem_spritesetEditor_Click;
             // 
             // toolStrip_connection
             // 
-            this.toolStrip_connection.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_connection.Enabled = false;
-            this.toolStrip_connection.Image = global::mage.Properties.Resources.toolbar_connection;
-            this.toolStrip_connection.Name = "toolStrip_connection";
-            this.toolStrip_connection.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_connection.Text = "Connection Editor";
-            this.toolStrip_connection.Click += new System.EventHandler(this.menuItem_connectionEditor_Click);
+            toolStrip_connection.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_connection.Enabled = false;
+            toolStrip_connection.Image = Properties.Resources.toolbar_connection;
+            toolStrip_connection.Name = "toolStrip_connection";
+            toolStrip_connection.Size = new System.Drawing.Size(23, 22);
+            toolStrip_connection.Text = "Connection Editor";
+            toolStrip_connection.Click += menuItem_connectionEditor_Click;
             // 
             // toolStrip_minimap
             // 
-            this.toolStrip_minimap.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_minimap.Enabled = false;
-            this.toolStrip_minimap.Image = global::mage.Properties.Resources.toolbar_minimap;
-            this.toolStrip_minimap.Name = "toolStrip_minimap";
-            this.toolStrip_minimap.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_minimap.Text = "Minimap Editor";
-            this.toolStrip_minimap.Click += new System.EventHandler(this.menuItem_minimapEditor_Click);
+            toolStrip_minimap.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_minimap.Enabled = false;
+            toolStrip_minimap.Image = Properties.Resources.toolbar_minimap;
+            toolStrip_minimap.Name = "toolStrip_minimap";
+            toolStrip_minimap.Size = new System.Drawing.Size(23, 22);
+            toolStrip_minimap.Text = "Minimap Editor";
+            toolStrip_minimap.Click += menuItem_minimapEditor_Click;
             // 
             // toolStrip_text
             // 
-            this.toolStrip_text.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_text.Enabled = false;
-            this.toolStrip_text.Image = global::mage.Properties.Resources.toolbar_text;
-            this.toolStrip_text.Name = "toolStrip_text";
-            this.toolStrip_text.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_text.Text = "Text Editor";
-            this.toolStrip_text.Click += new System.EventHandler(this.menuItem_textEditor_Click);
+            toolStrip_text.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_text.Enabled = false;
+            toolStrip_text.Image = Properties.Resources.toolbar_text;
+            toolStrip_text.Name = "toolStrip_text";
+            toolStrip_text.Size = new System.Drawing.Size(23, 22);
+            toolStrip_text.Text = "Text Editor";
+            toolStrip_text.Click += menuItem_textEditor_Click;
             // 
             // toolStrip_demoEditor
             // 
-            this.toolStrip_demoEditor.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_demoEditor.Enabled = false;
-            this.toolStrip_demoEditor.Image = global::mage.Properties.Resources.toolbar_demo;
-            this.toolStrip_demoEditor.Name = "toolStrip_demoEditor";
-            this.toolStrip_demoEditor.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_demoEditor.Text = "Demo Editor";
-            this.toolStrip_demoEditor.Click += new System.EventHandler(this.menuItem_demoEditor_Click);
+            toolStrip_demoEditor.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_demoEditor.Enabled = false;
+            toolStrip_demoEditor.Image = Properties.Resources.toolbar_demo;
+            toolStrip_demoEditor.Name = "toolStrip_demoEditor";
+            toolStrip_demoEditor.Size = new System.Drawing.Size(23, 22);
+            toolStrip_demoEditor.Text = "Demo Editor";
+            toolStrip_demoEditor.Click += menuItem_demoEditor_Click;
             // 
             // toolStrip_physics
             // 
-            this.toolStrip_physics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_physics.Enabled = false;
-            this.toolStrip_physics.Image = global::mage.Properties.Resources.toolbar_physics;
-            this.toolStrip_physics.Name = "toolStrip_physics";
-            this.toolStrip_physics.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_physics.Text = "Physics Editor";
-            this.toolStrip_physics.Click += new System.EventHandler(this.menuItem_physicsEditor_Click);
+            toolStrip_physics.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_physics.Enabled = false;
+            toolStrip_physics.Image = Properties.Resources.toolbar_physics;
+            toolStrip_physics.Name = "toolStrip_physics";
+            toolStrip_physics.Size = new System.Drawing.Size(23, 22);
+            toolStrip_physics.Text = "Physics Editor";
+            toolStrip_physics.Click += menuItem_physicsEditor_Click;
             // 
             // toolStrip_weapon
             // 
-            this.toolStrip_weapon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_weapon.Enabled = false;
-            this.toolStrip_weapon.Image = global::mage.Properties.Resources.toolbar_weapon;
-            this.toolStrip_weapon.Name = "toolStrip_weapon";
-            this.toolStrip_weapon.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_weapon.Text = "Weapon Editor";
-            this.toolStrip_weapon.Click += new System.EventHandler(this.menuItem_weaponEditor_Click);
+            toolStrip_weapon.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_weapon.Enabled = false;
+            toolStrip_weapon.Image = Properties.Resources.toolbar_weapon;
+            toolStrip_weapon.Name = "toolStrip_weapon";
+            toolStrip_weapon.Size = new System.Drawing.Size(23, 22);
+            toolStrip_weapon.Text = "Weapon Editor";
+            toolStrip_weapon.Click += menuItem_weaponEditor_Click;
             // 
             // toolStripSeparator11
             // 
-            this.toolStripSeparator11.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
-            this.toolStripSeparator11.Name = "toolStripSeparator11";
-            this.toolStripSeparator11.Size = new System.Drawing.Size(6, 25);
+            toolStripSeparator11.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
+            toolStripSeparator11.Name = "toolStripSeparator11";
+            toolStripSeparator11.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStrip_options
             // 
-            this.toolStrip_options.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_options.Enabled = false;
-            this.toolStrip_options.Image = global::mage.Properties.Resources.toolbar_options;
-            this.toolStrip_options.Name = "toolStrip_options";
-            this.toolStrip_options.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_options.Text = "Room Options";
-            this.toolStrip_options.Click += new System.EventHandler(this.menuItem_roomOptions_Click);
+            toolStrip_options.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_options.Enabled = false;
+            toolStrip_options.Image = Properties.Resources.toolbar_options;
+            toolStrip_options.Name = "toolStrip_options";
+            toolStrip_options.Size = new System.Drawing.Size(23, 22);
+            toolStrip_options.Text = "Room Options";
+            toolStrip_options.Click += menuItem_roomOptions_Click;
             // 
             // toolStrip_test
             // 
-            this.toolStrip_test.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_test.Enabled = false;
-            this.toolStrip_test.Image = global::mage.Properties.Resources.toolbar_test;
-            this.toolStrip_test.Name = "toolStrip_test";
-            this.toolStrip_test.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_test.Text = "Test Room";
-            this.toolStrip_test.Click += new System.EventHandler(this.menuItem_testRoom_Click);
+            toolStrip_test.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_test.Enabled = false;
+            toolStrip_test.Image = Properties.Resources.toolbar_test;
+            toolStrip_test.Name = "toolStrip_test";
+            toolStrip_test.Size = new System.Drawing.Size(23, 22);
+            toolStrip_test.Text = "Test Room";
+            toolStrip_test.Click += menuItem_testRoom_Click;
             // 
             // toolStrip_tileBuilder
             // 
-            this.toolStrip_tileBuilder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_tileBuilder.Enabled = false;
-            this.toolStrip_tileBuilder.Image = global::mage.Properties.Resources.toolbar_tile_builder;
-            this.toolStrip_tileBuilder.Name = "toolStrip_tileBuilder";
-            this.toolStrip_tileBuilder.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_tileBuilder.Text = "Minimap Tile Builder";
-            this.toolStrip_tileBuilder.Click += new System.EventHandler(this.menuItem_tileBuilder_Click);
+            toolStrip_tileBuilder.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_tileBuilder.Enabled = false;
+            toolStrip_tileBuilder.Image = Properties.Resources.toolbar_tile_builder;
+            toolStrip_tileBuilder.Name = "toolStrip_tileBuilder";
+            toolStrip_tileBuilder.Size = new System.Drawing.Size(23, 22);
+            toolStrip_tileBuilder.Text = "Minimap Tile Builder";
+            toolStrip_tileBuilder.Click += menuItem_tileBuilder_Click;
             // 
             // toolStrip_add
             // 
-            this.toolStrip_add.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_add.Enabled = false;
-            this.toolStrip_add.Image = global::mage.Properties.Resources.toolbar_add;
-            this.toolStrip_add.Name = "toolStrip_add";
-            this.toolStrip_add.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_add.Text = "Add";
-            this.toolStrip_add.Click += new System.EventHandler(this.toolStrip_add_Click);
+            toolStrip_add.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_add.Enabled = false;
+            toolStrip_add.Image = Properties.Resources.toolbar_add;
+            toolStrip_add.Name = "toolStrip_add";
+            toolStrip_add.Size = new System.Drawing.Size(23, 22);
+            toolStrip_add.Text = "Add";
+            toolStrip_add.Click += toolStrip_add_Click;
             // 
             // toolStrip_patches
             // 
-            this.toolStrip_patches.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStrip_patches.Enabled = false;
-            this.toolStrip_patches.Image = global::mage.Properties.Resources.toolbar_patches;
-            this.toolStrip_patches.Name = "toolStrip_patches";
-            this.toolStrip_patches.Size = new System.Drawing.Size(23, 22);
-            this.toolStrip_patches.Text = "Patches";
-            this.toolStrip_patches.Click += new System.EventHandler(this.menuItem_patches_Click);
+            toolStrip_patches.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStrip_patches.Enabled = false;
+            toolStrip_patches.Image = Properties.Resources.toolbar_patches;
+            toolStrip_patches.Name = "toolStrip_patches";
+            toolStrip_patches.Size = new System.Drawing.Size(23, 22);
+            toolStrip_patches.Text = "Patches";
+            toolStrip_patches.Click += menuItem_patches_Click;
             // 
             // comboBox_spriteset
             // 
-            this.comboBox_spriteset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_spriteset.FormattingEnabled = true;
-            this.comboBox_spriteset.Location = new System.Drawing.Point(70, 132);
-            this.comboBox_spriteset.Name = "comboBox_spriteset";
-            this.comboBox_spriteset.Size = new System.Drawing.Size(68, 21);
-            this.comboBox_spriteset.TabIndex = 11;
-            this.comboBox_spriteset.SelectedIndexChanged += new System.EventHandler(this.comboBox_spriteset_SelectedIndexChanged);
+            comboBox_spriteset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBox_spriteset.FormattingEnabled = true;
+            comboBox_spriteset.Location = new System.Drawing.Point(82, 152);
+            comboBox_spriteset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            comboBox_spriteset.Name = "comboBox_spriteset";
+            comboBox_spriteset.Size = new System.Drawing.Size(79, 23);
+            comboBox_spriteset.TabIndex = 11;
+            comboBox_spriteset.SelectedIndexChanged += comboBox_spriteset_SelectedIndexChanged;
             // 
             // FormMain
             // 
-            this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(796, 497);
-            this.Controls.Add(this.comboBox_spriteset);
-            this.Controls.Add(this.toolStrip);
-            this.Controls.Add(this.label_spriteset);
-            this.Controls.Add(this.statusStrip);
-            this.Controls.Add(this.groupBox_editBG);
-            this.Controls.Add(this.groupBox_viewBG);
-            this.Controls.Add(this.groupBox_room);
-            this.Controls.Add(this.groupBox_tileset);
-            this.Controls.Add(this.groupBox_location);
-            this.Controls.Add(this.menuStrip);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.KeyPreview = true;
-            this.MainMenuStrip = this.menuStrip;
-            this.MinimumSize = new System.Drawing.Size(812, 536);
-            this.Name = "FormMain";
-            this.Text = "MAGE 1.4";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMain_FormClosing);
-            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.FormMain_DragDrop);
-            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.FormMain_DragEnter);
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.FormMain_KeyDown);
-            this.menuStrip.ResumeLayout(false);
-            this.menuStrip.PerformLayout();
-            this.groupBox_location.ResumeLayout(false);
-            this.groupBox_location.PerformLayout();
-            this.groupBox_tileset.ResumeLayout(false);
-            this.groupBox_tileset.PerformLayout();
-            this.panel_tileset.ResumeLayout(false);
-            this.groupBox_room.ResumeLayout(false);
-            this.panel_room.ResumeLayout(false);
-            this.contextMenu.ResumeLayout(false);
-            this.groupBox_viewBG.ResumeLayout(false);
-            this.groupBox_viewBG.PerformLayout();
-            this.groupBox_editBG.ResumeLayout(false);
-            this.groupBox_editBG.PerformLayout();
-            this.statusStrip.ResumeLayout(false);
-            this.statusStrip.PerformLayout();
-            this.toolStrip.ResumeLayout(false);
-            this.toolStrip.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AllowDrop = true;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(929, 573);
+            Controls.Add(comboBox_spriteset);
+            Controls.Add(toolStrip);
+            Controls.Add(label_spriteset);
+            Controls.Add(statusStrip);
+            Controls.Add(groupBox_editBG);
+            Controls.Add(groupBox_viewBG);
+            Controls.Add(groupBox_room);
+            Controls.Add(groupBox_tileset);
+            Controls.Add(groupBox_location);
+            Controls.Add(menuStrip);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            KeyPreview = true;
+            MainMenuStrip = menuStrip;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MinimumSize = new System.Drawing.Size(945, 612);
+            Name = "FormMain";
+            Text = "MAGE 1.4";
+            FormClosing += FormMain_FormClosing;
+            DragDrop += FormMain_DragDrop;
+            DragEnter += FormMain_DragEnter;
+            KeyDown += FormMain_KeyDown;
+            menuStrip.ResumeLayout(false);
+            menuStrip.PerformLayout();
+            groupBox_location.ResumeLayout(false);
+            groupBox_location.PerformLayout();
+            groupBox_tileset.ResumeLayout(false);
+            groupBox_tileset.PerformLayout();
+            panel_tileset.ResumeLayout(false);
+            groupBox_room.ResumeLayout(false);
+            panel_room.ResumeLayout(false);
+            contextMenu.ResumeLayout(false);
+            groupBox_viewBG.ResumeLayout(false);
+            groupBox_viewBG.PerformLayout();
+            groupBox_editBG.ResumeLayout(false);
+            groupBox_editBG.PerformLayout();
+            statusStrip.ResumeLayout(false);
+            statusStrip.PerformLayout();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/mage/FormMain.Designer.cs
+++ b/mage/FormMain.Designer.cs
@@ -1983,7 +1983,7 @@
             // 
             comboBox_spriteset.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             comboBox_spriteset.FormattingEnabled = true;
-            comboBox_spriteset.Location = new System.Drawing.Point(82, 152);
+            comboBox_spriteset.Location = new System.Drawing.Point(81, 153);
             comboBox_spriteset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             comboBox_spriteset.Name = "comboBox_spriteset";
             comboBox_spriteset.Size = new System.Drawing.Size(79, 23);

--- a/mage/FormMain.cs
+++ b/mage/FormMain.cs
@@ -1653,6 +1653,20 @@ namespace mage
             roomView.RedrawAll();
         }
 
+        public void UpdateUiAfterClear()
+        {
+            menuItem_outlineSprites.Enabled = menuItem_viewSprites.Enabled =
+                        toolStrip_outlineSprites.Enabled = toolStrip_viewSprites.Enabled = room.enemyList.Count > 0;
+            menuItem_viewSprites.Checked = toolStrip_viewSprites.Checked = toolStrip_viewSprites.Enabled;
+            menuItem_outlineSprites.Checked = toolStrip_outlineSprites.Checked = toolStrip_outlineSprites.Enabled;
+
+            menuItem_outlineDoors.Enabled = toolStrip_outlineDoors.Enabled = room.doorList.Count > 0;
+            menuItem_outlineDoors.Checked = toolStrip_outlineDoors.Checked = toolStrip_outlineDoors.Enabled;
+
+            menuItem_outlineScrolls.Enabled = toolStrip_outlineScrolls.Enabled = room.scrollList.Count > 0;
+            menuItem_outlineScrolls.Checked = toolStrip_outlineScrolls.Checked = toolStrip_outlineScrolls.Enabled;
+        }
+
         private void UpdateUndoRedo()
         {
             menuItem_undo.Enabled = toolStrip_undo.Enabled = undoRedo.CanUndo;

--- a/mage/FormMain.cs
+++ b/mage/FormMain.cs
@@ -81,12 +81,13 @@ namespace mage
             InitializeSettings();
             ShowSplash();
 
+            roomView.Scrolled += roomView_Scrolled;
+
             ThemeSwitcher.ChangeTheme(Controls, this);
             ThemeSwitcher.InjectPaintOverrides(Controls);
 
             ThemeSwitcher.TestSerialisation();
         }
-
 
         #region opening/closing
 
@@ -2338,6 +2339,15 @@ namespace mage
         private void roomView_MouseLeave(object sender, EventArgs e)
         {
             ResetRoomTip(false);
+        }
+
+        private void roomView_Scrolled(object sender, MouseEventArgs e)
+        {
+            if ((ModifierKeys & Keys.Control) == Keys.Control)
+            {
+                if (e.Delta > 0) UpdateZoom(zoom + 1);
+                if (e.Delta < 0) UpdateZoom(zoom - 1);
+            }
         }
 
         #endregion

--- a/mage/FormMain.cs
+++ b/mage/FormMain.cs
@@ -12,7 +12,7 @@ namespace mage
 {
     public partial class FormMain : Form, Editor
     {
-        
+
         #region properties
 
         public Room Room
@@ -36,7 +36,7 @@ namespace mage
                     || checkBox_editBG2.Checked || checkBox_editCLP.Checked);
             }
         }
-        
+
         public bool ViewSprites { get { return toolStrip_viewSprites.Checked; } }
         public bool OutlineSprites { get { return toolStrip_outlineSprites.Checked; } }
         public bool OutlineDoors { get { return toolStrip_outlineDoors.Checked; } }
@@ -52,7 +52,7 @@ namespace mage
         }
 
         #endregion
-        
+
         #region fields
 
         private PictureBox splash;
@@ -122,7 +122,7 @@ namespace mage
             int index = recent.IndexOf(filename);
             if (index != -1)
             {
-                recent.RemoveAt(index);   
+                recent.RemoveAt(index);
             }
             else
             {
@@ -248,7 +248,7 @@ namespace mage
         }
 
         #endregion
-        
+
 
         #region menu strip
 
@@ -1274,9 +1274,9 @@ namespace mage
             // BG viewing
             menuItem_viewBG0.Enabled = checkBox_viewBG0.Enabled = exists[0];
             menuItem_editBG0.Enabled = checkBox_editBG0.Enabled = room.BG0.IsRLE;
-            menuItem_viewBG1.Enabled = menuItem_editBG1.Enabled = 
+            menuItem_viewBG1.Enabled = menuItem_editBG1.Enabled =
                 checkBox_viewBG1.Enabled = checkBox_editBG1.Enabled = exists[1];
-            menuItem_viewBG2.Enabled = menuItem_editBG2.Enabled = 
+            menuItem_viewBG2.Enabled = menuItem_editBG2.Enabled =
                 checkBox_viewBG2.Enabled = checkBox_editBG2.Enabled = exists[2];
             menuItem_viewBG3.Enabled = checkBox_viewBG3.Enabled = exists[3];
 
@@ -1497,7 +1497,7 @@ namespace mage
 
         private void UpdateBGs()
         {
-            bool[] view = new bool[] { checkBox_viewBG0.Checked, checkBox_viewBG1.Checked, 
+            bool[] view = new bool[] { checkBox_viewBG0.Checked, checkBox_viewBG1.Checked,
                 checkBox_viewBG2.Checked, checkBox_viewBG3.Checked };
             room.backgrounds.View = view;
             roomView.RedrawAll();
@@ -1581,7 +1581,7 @@ namespace mage
             room.vramObj = new VramObj(room.spritesets[enemySet]);
             roomView.RedrawAll();
         }
-        
+
         private void UpdateRoomNumbers()
         {
             for (int i = 0; i < comboBox_room.Items.Count; i++)
@@ -1622,7 +1622,7 @@ namespace mage
             {
                 if (a.ActionText.Contains("sprite"))
                 {
-                    menuItem_outlineSprites.Enabled = menuItem_viewSprites.Enabled = 
+                    menuItem_outlineSprites.Enabled = menuItem_viewSprites.Enabled =
                         toolStrip_outlineSprites.Enabled = toolStrip_viewSprites.Enabled = room.enemyList.Count > 0;
                     menuItem_viewSprites.Checked = toolStrip_viewSprites.Checked = toolStrip_viewSprites.Enabled;
                     menuItem_outlineSprites.Checked = toolStrip_outlineSprites.Checked = toolStrip_outlineSprites.Enabled;
@@ -2244,7 +2244,7 @@ namespace mage
                     else if (selScroll != -1)
                     {
                         obj = room.scrollList[selScroll / 6];
-                        selObject = selScroll;                  
+                        selObject = selScroll;
                     }
 
                     if (selObject != -1)
@@ -2314,6 +2314,15 @@ namespace mage
                     roomView.Invalidate(rect);
                 }
             }
+        }
+
+        private void roomView_DoubleClick(object sender, EventArgs e)
+        {
+            if (EditBGs) return;
+            SelectObjects();
+            if (selEnemy != -1) contextItem_editSprite_Click(new object(), new EventArgs());
+            else if (selDoor != -1) contextItem_editDoor_Click(new object(), new EventArgs());
+            else if (selScroll != -1) contextItem_editScroll_Click(new object(), new EventArgs());
         }
 
         private void roomView_MouseLeave(object sender, EventArgs e)

--- a/mage/FormMain.resx
+++ b/mage/FormMain.resx
@@ -120,6 +120,9 @@
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>487, 20</value>
+  </metadata>
   <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>363, 20</value>
   </metadata>

--- a/mage/FormMain.resx
+++ b/mage/FormMain.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,22 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>363, 20</value>
   </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>132, 17</value>
   </metadata>
-  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>265, 20</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>39</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAEBAAAAAAGABoAwAAJgAAACAgAAAAABgAqAwAAI4DAAAoAAAAEAAAACAAAAABABgAAAAAAAAD

--- a/mage/Program.cs
+++ b/mage/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.IO;
 using System.Runtime.Versioning;
 using System.Windows.Forms;
@@ -16,6 +17,7 @@ namespace mage
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8f));
 
             // check for opening rom directly
             string[] args = Environment.GetCommandLineArgs();

--- a/mage/Room/DoorList.cs
+++ b/mage/Room/DoorList.cs
@@ -133,6 +133,17 @@ namespace mage
             doors.RemoveAt(num);
         }
 
+        public void Clear()
+        {
+            Edited = true;
+            foreach(Door d in doors)
+            {
+                d.Edited = true;
+                d.srcRoom = 0xFF;
+            }
+            doors.Clear();
+        }
+
         public void Export(ByteStream dst)
         {
             dst.Write8((byte)NumOfDoors);

--- a/mage/Room/EnemyList.cs
+++ b/mage/Room/EnemyList.cs
@@ -220,6 +220,10 @@ namespace mage
             }
         }
 
-
+        public void Clear()
+        {
+            Edited = true;
+            enemies.Clear();
+        }
     }
 }

--- a/mage/Room/ScrollList.cs
+++ b/mage/Room/ScrollList.cs
@@ -246,6 +246,12 @@ namespace mage
             scrolls.RemoveAt(num / 6);
         }
 
+        public void Clear()
+        {
+            Edited = true;
+            scrolls.Clear();
+        }
+
         public void Export(ByteStream dst)
         {
             dst.Write8((byte)scrolls.Count);

--- a/mage/RoomView.cs
+++ b/mage/RoomView.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 
 namespace mage
 {
-    public partial class RoomView : Control
+    public partial class RoomView : ScrollableControl
     {
         // properties
         public bool HasSelection
@@ -222,6 +222,12 @@ namespace mage
             base.OnPaintBackground(pevent);
         }
 
+        public event EventHandler<MouseEventArgs> Scrolled;
 
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            Scrolled.Invoke(this, e);
+            base.OnMouseWheel(e);
+        }
     }
 }

--- a/mage/Theming/CustomControls/FlatTextBox.cs
+++ b/mage/Theming/CustomControls/FlatTextBox.cs
@@ -63,7 +63,7 @@ partial class FlatTextBox : UserControl
         }
     }
 
-    public new string Text { get => textBox.Text; set => textBox.Text = value; }
+    public override string Text { get => textBox.Text; set => textBox.Text = value; }
 
     public bool WordWrap { get => textBox.WordWrap; set => textBox.WordWrap = value; }
 

--- a/mage/Theming/CustomControls/FlatTextBox.cs
+++ b/mage/Theming/CustomControls/FlatTextBox.cs
@@ -78,18 +78,21 @@ partial class FlatTextBox : UserControl
     #endregion
 
     #region events
-    public new event EventHandler TextChanged
+    public new event EventHandler TextChanged;
+
+    private void textBoxTextChanged(object sender, EventArgs e)
     {
-        add { textBox.TextChanged += value; }
-        remove { textBox.TextChanged -= value; }
+        TextChanged?.Invoke(this, e);
     }
     #endregion
 
     public FlatTextBox()
     {
         InitializeComponent();
+        textBox.TextChanged += textBoxTextChanged;
     }
 
+    #region methods
     protected override void OnPaint(PaintEventArgs e)
     {
         base.OnPaint(e);
@@ -118,4 +121,5 @@ partial class FlatTextBox : UserControl
 
     //Conversions
     public static implicit operator TextBox(FlatTextBox b) => b.textBox;
+    #endregion
 }

--- a/mage/Theming/CustomControls/FlatTextBox.cs
+++ b/mage/Theming/CustomControls/FlatTextBox.cs
@@ -82,11 +82,16 @@ partial class FlatTextBox : UserControl
     #endregion
 
     #region events
-    public new event EventHandler TextChanged;
+    public new event EventHandler TextChanged
+    {
+        add => OnTextChanged += value;
+        remove => OnTextChanged -= value;
+    }
+    public EventHandler OnTextChanged { get; set; }
 
     private void textBoxTextChanged(object sender, EventArgs e)
     {
-        TextChanged?.Invoke(this, e);
+        OnTextChanged?.Invoke(this, e);
     }
     #endregion
 

--- a/mage/Theming/CustomControls/FlatTextBox.cs
+++ b/mage/Theming/CustomControls/FlatTextBox.cs
@@ -46,20 +46,24 @@ partial class FlatTextBox : UserControl
 
     public new BorderStyle BorderStyle
     {
-        get => textBox.BorderStyle;
+        get => (BorderStyle)base.BorderStyle;
         set
         {
-            drawBorder = true;
             if (value == BorderStyle.None)
             {
                 textBox.Location = new Point(0, 0);
                 drawBorder = false;
             }
-            else textBox.Location = new Point(3, 3);
+            else
+            {
+                textBox.Location = new Point(3, 3);
+                drawBorder = true;
+            }
+            base.BorderStyle = BorderStyle.None;
         }
     }
 
-    public override string Text { get => textBox.Text; set => textBox.Text = value; }
+    public new string Text { get => textBox.Text; set => textBox.Text = value; }
 
     public bool WordWrap { get => textBox.WordWrap; set => textBox.WordWrap = value; }
 

--- a/mage/Tools/FormRoomOptions.Designer.cs
+++ b/mage/Tools/FormRoomOptions.Designer.cs
@@ -29,221 +29,264 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormRoomOptions));
-            this.textBox_width = new mage.Theming.CustomControls.FlatTextBox();
-            this.textBox_height = new mage.Theming.CustomControls.FlatTextBox();
-            this.label_width = new System.Windows.Forms.Label();
-            this.label_height = new System.Windows.Forms.Label();
-            this.button_resize = new System.Windows.Forms.Button();
-            this.button_clearBG = new System.Windows.Forms.Button();
-            this.checkBox_bg0 = new System.Windows.Forms.CheckBox();
-            this.checkBox_bg1 = new System.Windows.Forms.CheckBox();
-            this.checkBox_bg2 = new System.Windows.Forms.CheckBox();
-            this.checkBox_clip = new System.Windows.Forms.CheckBox();
-            this.groupBox_resize = new System.Windows.Forms.GroupBox();
-            this.label_blocks = new System.Windows.Forms.Label();
-            this.label_screenY = new System.Windows.Forms.Label();
-            this.label_screenX = new System.Windows.Forms.Label();
-            this.label_screens = new System.Windows.Forms.Label();
-            this.groupBox_clear = new System.Windows.Forms.GroupBox();
-            this.button_close = new System.Windows.Forms.Button();
-            this.groupBox_resize.SuspendLayout();
-            this.groupBox_clear.SuspendLayout();
-            this.SuspendLayout();
+            textBox_width = new Theming.CustomControls.FlatTextBox();
+            textBox_height = new Theming.CustomControls.FlatTextBox();
+            label_width = new System.Windows.Forms.Label();
+            label_height = new System.Windows.Forms.Label();
+            button_resize = new System.Windows.Forms.Button();
+            button_clearBG = new System.Windows.Forms.Button();
+            checkBox_bg0 = new System.Windows.Forms.CheckBox();
+            checkBox_bg1 = new System.Windows.Forms.CheckBox();
+            checkBox_bg2 = new System.Windows.Forms.CheckBox();
+            checkBox_clip = new System.Windows.Forms.CheckBox();
+            groupBox_resize = new System.Windows.Forms.GroupBox();
+            textbox_screenY = new Theming.CustomControls.FlatTextBox();
+            textbox_screenX = new Theming.CustomControls.FlatTextBox();
+            label_blocks = new System.Windows.Forms.Label();
+            label_screens = new System.Windows.Forms.Label();
+            groupBox_clear = new System.Windows.Forms.GroupBox();
+            button_close = new System.Windows.Forms.Button();
+            groupBox_resize.SuspendLayout();
+            groupBox_clear.SuspendLayout();
+            SuspendLayout();
             // 
             // textBox_width
             // 
-            this.textBox_width.Location = new System.Drawing.Point(53, 32);
-            this.textBox_width.Name = "textBox_width";
-            this.textBox_width.Size = new System.Drawing.Size(29, 20);
-            this.textBox_width.TabIndex = 0;
-            this.textBox_width.TextChanged += new System.EventHandler(this.textBox_width_TextChanged);
+            textBox_width.BorderColor = System.Drawing.Color.Black;
+            textBox_width.Location = new System.Drawing.Point(62, 37);
+            textBox_width.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_width.Multiline = false;
+            textBox_width.Name = "textBox_width";
+            textBox_width.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_width.ReadOnly = false;
+            textBox_width.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_width.SelectionStart = 0;
+            textBox_width.Size = new System.Drawing.Size(34, 23);
+            textBox_width.TabIndex = 0;
+            textBox_width.WordWrap = true;
+            textBox_width.TextChanged += textBox_width_TextChanged;
             // 
             // textBox_height
             // 
-            this.textBox_height.Location = new System.Drawing.Point(53, 58);
-            this.textBox_height.Name = "textBox_height";
-            this.textBox_height.Size = new System.Drawing.Size(29, 20);
-            this.textBox_height.TabIndex = 1;
-            this.textBox_height.TextChanged += new System.EventHandler(this.textBox_height_TextChanged);
+            textBox_height.BorderColor = System.Drawing.Color.Black;
+            textBox_height.Location = new System.Drawing.Point(62, 67);
+            textBox_height.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox_height.Multiline = false;
+            textBox_height.Name = "textBox_height";
+            textBox_height.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textBox_height.ReadOnly = false;
+            textBox_height.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textBox_height.SelectionStart = 0;
+            textBox_height.Size = new System.Drawing.Size(34, 23);
+            textBox_height.TabIndex = 1;
+            textBox_height.WordWrap = true;
+            textBox_height.TextChanged += textBox_height_TextChanged;
             // 
             // label_width
             // 
-            this.label_width.AutoSize = true;
-            this.label_width.Location = new System.Drawing.Point(6, 35);
-            this.label_width.Name = "label_width";
-            this.label_width.Size = new System.Drawing.Size(38, 13);
-            this.label_width.TabIndex = 0;
-            this.label_width.Text = "Width:";
+            label_width.AutoSize = true;
+            label_width.Location = new System.Drawing.Point(7, 40);
+            label_width.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_width.Name = "label_width";
+            label_width.Size = new System.Drawing.Size(42, 15);
+            label_width.TabIndex = 0;
+            label_width.Text = "Width:";
             // 
             // label_height
             // 
-            this.label_height.AutoSize = true;
-            this.label_height.Location = new System.Drawing.Point(6, 61);
-            this.label_height.Name = "label_height";
-            this.label_height.Size = new System.Drawing.Size(41, 13);
-            this.label_height.TabIndex = 0;
-            this.label_height.Text = "Height:";
+            label_height.AutoSize = true;
+            label_height.Location = new System.Drawing.Point(7, 70);
+            label_height.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_height.Name = "label_height";
+            label_height.Size = new System.Drawing.Size(46, 15);
+            label_height.TabIndex = 0;
+            label_height.Text = "Height:";
             // 
             // button_resize
             // 
-            this.button_resize.Location = new System.Drawing.Point(7, 84);
-            this.button_resize.Name = "button_resize";
-            this.button_resize.Size = new System.Drawing.Size(75, 23);
-            this.button_resize.TabIndex = 2;
-            this.button_resize.Text = "Resize";
-            this.button_resize.UseVisualStyleBackColor = true;
-            this.button_resize.Click += new System.EventHandler(this.button_resize_Click);
+            button_resize.Location = new System.Drawing.Point(8, 97);
+            button_resize.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_resize.Name = "button_resize";
+            button_resize.Size = new System.Drawing.Size(88, 27);
+            button_resize.TabIndex = 2;
+            button_resize.Text = "Resize";
+            button_resize.UseVisualStyleBackColor = true;
+            button_resize.Click += button_resize_Click;
             // 
             // button_clearBG
             // 
-            this.button_clearBG.Location = new System.Drawing.Point(6, 111);
-            this.button_clearBG.Name = "button_clearBG";
-            this.button_clearBG.Size = new System.Drawing.Size(75, 23);
-            this.button_clearBG.TabIndex = 4;
-            this.button_clearBG.Text = "Clear";
-            this.button_clearBG.UseVisualStyleBackColor = true;
-            this.button_clearBG.Click += new System.EventHandler(this.button_clearBG_Click);
+            button_clearBG.Location = new System.Drawing.Point(7, 128);
+            button_clearBG.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_clearBG.Name = "button_clearBG";
+            button_clearBG.Size = new System.Drawing.Size(88, 27);
+            button_clearBG.TabIndex = 4;
+            button_clearBG.Text = "Clear";
+            button_clearBG.UseVisualStyleBackColor = true;
+            button_clearBG.Click += button_clearBG_Click;
             // 
             // checkBox_bg0
             // 
-            this.checkBox_bg0.AutoSize = true;
-            this.checkBox_bg0.Location = new System.Drawing.Point(10, 19);
-            this.checkBox_bg0.Name = "checkBox_bg0";
-            this.checkBox_bg0.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_bg0.TabIndex = 0;
-            this.checkBox_bg0.Text = "BG 0";
-            this.checkBox_bg0.UseVisualStyleBackColor = true;
+            checkBox_bg0.AutoSize = true;
+            checkBox_bg0.Location = new System.Drawing.Point(12, 22);
+            checkBox_bg0.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_bg0.Name = "checkBox_bg0";
+            checkBox_bg0.Size = new System.Drawing.Size(50, 19);
+            checkBox_bg0.TabIndex = 0;
+            checkBox_bg0.Text = "BG 0";
+            checkBox_bg0.UseVisualStyleBackColor = true;
             // 
             // checkBox_bg1
             // 
-            this.checkBox_bg1.AutoSize = true;
-            this.checkBox_bg1.Location = new System.Drawing.Point(10, 42);
-            this.checkBox_bg1.Name = "checkBox_bg1";
-            this.checkBox_bg1.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_bg1.TabIndex = 1;
-            this.checkBox_bg1.Text = "BG 1";
-            this.checkBox_bg1.UseVisualStyleBackColor = true;
+            checkBox_bg1.AutoSize = true;
+            checkBox_bg1.Location = new System.Drawing.Point(12, 48);
+            checkBox_bg1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_bg1.Name = "checkBox_bg1";
+            checkBox_bg1.Size = new System.Drawing.Size(50, 19);
+            checkBox_bg1.TabIndex = 1;
+            checkBox_bg1.Text = "BG 1";
+            checkBox_bg1.UseVisualStyleBackColor = true;
             // 
             // checkBox_bg2
             // 
-            this.checkBox_bg2.AutoSize = true;
-            this.checkBox_bg2.Location = new System.Drawing.Point(10, 65);
-            this.checkBox_bg2.Name = "checkBox_bg2";
-            this.checkBox_bg2.Size = new System.Drawing.Size(50, 17);
-            this.checkBox_bg2.TabIndex = 2;
-            this.checkBox_bg2.Text = "BG 2";
-            this.checkBox_bg2.UseVisualStyleBackColor = true;
+            checkBox_bg2.AutoSize = true;
+            checkBox_bg2.Location = new System.Drawing.Point(12, 75);
+            checkBox_bg2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_bg2.Name = "checkBox_bg2";
+            checkBox_bg2.Size = new System.Drawing.Size(50, 19);
+            checkBox_bg2.TabIndex = 2;
+            checkBox_bg2.Text = "BG 2";
+            checkBox_bg2.UseVisualStyleBackColor = true;
             // 
             // checkBox_clip
             // 
-            this.checkBox_clip.AutoSize = true;
-            this.checkBox_clip.Location = new System.Drawing.Point(10, 88);
-            this.checkBox_clip.Name = "checkBox_clip";
-            this.checkBox_clip.Size = new System.Drawing.Size(64, 17);
-            this.checkBox_clip.TabIndex = 3;
-            this.checkBox_clip.Text = "Clipdata";
-            this.checkBox_clip.UseVisualStyleBackColor = true;
+            checkBox_clip.AutoSize = true;
+            checkBox_clip.Location = new System.Drawing.Point(12, 102);
+            checkBox_clip.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_clip.Name = "checkBox_clip";
+            checkBox_clip.Size = new System.Drawing.Size(70, 19);
+            checkBox_clip.TabIndex = 3;
+            checkBox_clip.Text = "Clipdata";
+            checkBox_clip.UseVisualStyleBackColor = true;
             // 
             // groupBox_resize
             // 
-            this.groupBox_resize.Controls.Add(this.label_blocks);
-            this.groupBox_resize.Controls.Add(this.label_screenY);
-            this.groupBox_resize.Controls.Add(this.label_screenX);
-            this.groupBox_resize.Controls.Add(this.label_screens);
-            this.groupBox_resize.Controls.Add(this.label_width);
-            this.groupBox_resize.Controls.Add(this.textBox_width);
-            this.groupBox_resize.Controls.Add(this.textBox_height);
-            this.groupBox_resize.Controls.Add(this.label_height);
-            this.groupBox_resize.Controls.Add(this.button_resize);
-            this.groupBox_resize.Location = new System.Drawing.Point(105, 12);
-            this.groupBox_resize.Name = "groupBox_resize";
-            this.groupBox_resize.Size = new System.Drawing.Size(147, 113);
-            this.groupBox_resize.TabIndex = 1;
-            this.groupBox_resize.TabStop = false;
-            this.groupBox_resize.Text = "Resize Room";
+            groupBox_resize.Controls.Add(textbox_screenY);
+            groupBox_resize.Controls.Add(textbox_screenX);
+            groupBox_resize.Controls.Add(label_blocks);
+            groupBox_resize.Controls.Add(label_screens);
+            groupBox_resize.Controls.Add(label_width);
+            groupBox_resize.Controls.Add(textBox_width);
+            groupBox_resize.Controls.Add(textBox_height);
+            groupBox_resize.Controls.Add(label_height);
+            groupBox_resize.Controls.Add(button_resize);
+            groupBox_resize.Location = new System.Drawing.Point(122, 14);
+            groupBox_resize.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_resize.Name = "groupBox_resize";
+            groupBox_resize.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_resize.Size = new System.Drawing.Size(172, 130);
+            groupBox_resize.TabIndex = 1;
+            groupBox_resize.TabStop = false;
+            groupBox_resize.Text = "Resize Room";
+            // 
+            // textbox_screenY
+            // 
+            textbox_screenY.BorderColor = System.Drawing.Color.Black;
+            textbox_screenY.Location = new System.Drawing.Point(116, 67);
+            textbox_screenY.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textbox_screenY.Multiline = false;
+            textbox_screenY.Name = "textbox_screenY";
+            textbox_screenY.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textbox_screenY.ReadOnly = false;
+            textbox_screenY.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textbox_screenY.SelectionStart = 0;
+            textbox_screenY.Size = new System.Drawing.Size(34, 23);
+            textbox_screenY.TabIndex = 4;
+            textbox_screenY.WordWrap = true;
+            // 
+            // textbox_screenX
+            // 
+            textbox_screenX.BorderColor = System.Drawing.Color.Black;
+            textbox_screenX.Location = new System.Drawing.Point(116, 37);
+            textbox_screenX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textbox_screenX.Multiline = false;
+            textbox_screenX.Name = "textbox_screenX";
+            textbox_screenX.Padding = new System.Windows.Forms.Padding(4, 3, 1, 2);
+            textbox_screenX.ReadOnly = false;
+            textbox_screenX.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            textbox_screenX.SelectionStart = 0;
+            textbox_screenX.Size = new System.Drawing.Size(34, 23);
+            textbox_screenX.TabIndex = 3;
+            textbox_screenX.WordWrap = true;
             // 
             // label_blocks
             // 
-            this.label_blocks.AutoSize = true;
-            this.label_blocks.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_blocks.Location = new System.Drawing.Point(50, 16);
-            this.label_blocks.Name = "label_blocks";
-            this.label_blocks.Size = new System.Drawing.Size(39, 13);
-            this.label_blocks.TabIndex = 0;
-            this.label_blocks.Text = "Blocks";
-            // 
-            // label_screenY
-            // 
-            this.label_screenY.AutoSize = true;
-            this.label_screenY.Location = new System.Drawing.Point(95, 61);
-            this.label_screenY.Name = "label_screenY";
-            this.label_screenY.Size = new System.Drawing.Size(13, 13);
-            this.label_screenY.TabIndex = 0;
-            this.label_screenY.Text = "0";
-            // 
-            // label_screenX
-            // 
-            this.label_screenX.AutoSize = true;
-            this.label_screenX.Location = new System.Drawing.Point(95, 35);
-            this.label_screenX.Name = "label_screenX";
-            this.label_screenX.Size = new System.Drawing.Size(13, 13);
-            this.label_screenX.TabIndex = 0;
-            this.label_screenX.Text = "0";
+            label_blocks.AutoSize = true;
+            label_blocks.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_blocks.Location = new System.Drawing.Point(58, 18);
+            label_blocks.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_blocks.Name = "label_blocks";
+            label_blocks.Size = new System.Drawing.Size(39, 13);
+            label_blocks.TabIndex = 0;
+            label_blocks.Text = "Blocks";
             // 
             // label_screens
             // 
-            this.label_screens.AutoSize = true;
-            this.label_screens.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_screens.Location = new System.Drawing.Point(95, 16);
-            this.label_screens.Name = "label_screens";
-            this.label_screens.Size = new System.Drawing.Size(46, 13);
-            this.label_screens.TabIndex = 0;
-            this.label_screens.Text = "Screens";
+            label_screens.AutoSize = true;
+            label_screens.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point);
+            label_screens.Location = new System.Drawing.Point(111, 18);
+            label_screens.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label_screens.Name = "label_screens";
+            label_screens.Size = new System.Drawing.Size(46, 13);
+            label_screens.TabIndex = 0;
+            label_screens.Text = "Screens";
             // 
             // groupBox_clear
             // 
-            this.groupBox_clear.Controls.Add(this.checkBox_bg0);
-            this.groupBox_clear.Controls.Add(this.checkBox_bg1);
-            this.groupBox_clear.Controls.Add(this.button_clearBG);
-            this.groupBox_clear.Controls.Add(this.checkBox_bg2);
-            this.groupBox_clear.Controls.Add(this.checkBox_clip);
-            this.groupBox_clear.Location = new System.Drawing.Point(12, 12);
-            this.groupBox_clear.Name = "groupBox_clear";
-            this.groupBox_clear.Size = new System.Drawing.Size(87, 140);
-            this.groupBox_clear.TabIndex = 0;
-            this.groupBox_clear.TabStop = false;
-            this.groupBox_clear.Text = "Clear BG";
+            groupBox_clear.Controls.Add(checkBox_bg0);
+            groupBox_clear.Controls.Add(checkBox_bg1);
+            groupBox_clear.Controls.Add(button_clearBG);
+            groupBox_clear.Controls.Add(checkBox_bg2);
+            groupBox_clear.Controls.Add(checkBox_clip);
+            groupBox_clear.Location = new System.Drawing.Point(14, 14);
+            groupBox_clear.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_clear.Name = "groupBox_clear";
+            groupBox_clear.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox_clear.Size = new System.Drawing.Size(102, 162);
+            groupBox_clear.TabIndex = 0;
+            groupBox_clear.TabStop = false;
+            groupBox_clear.Text = "Clear BG";
             // 
             // button_close
             // 
-            this.button_close.Location = new System.Drawing.Point(177, 131);
-            this.button_close.Name = "button_close";
-            this.button_close.Size = new System.Drawing.Size(75, 23);
-            this.button_close.TabIndex = 2;
-            this.button_close.Text = "Close";
-            this.button_close.UseVisualStyleBackColor = true;
-            this.button_close.Click += new System.EventHandler(this.button_close_Click);
+            button_close.Location = new System.Drawing.Point(206, 151);
+            button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button_close.Name = "button_close";
+            button_close.Size = new System.Drawing.Size(88, 27);
+            button_close.TabIndex = 2;
+            button_close.Text = "Close";
+            button_close.UseVisualStyleBackColor = true;
+            button_close.Click += button_close_Click;
             // 
             // FormRoomOptions
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(264, 166);
-            this.Controls.Add(this.button_close);
-            this.Controls.Add(this.groupBox_clear);
-            this.Controls.Add(this.groupBox_resize);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "FormRoomOptions";
-            this.Text = "Room Options";
-            this.groupBox_resize.ResumeLayout(false);
-            this.groupBox_resize.PerformLayout();
-            this.groupBox_clear.ResumeLayout(false);
-            this.groupBox_clear.PerformLayout();
-            this.ResumeLayout(false);
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(308, 192);
+            Controls.Add(button_close);
+            Controls.Add(groupBox_clear);
+            Controls.Add(groupBox_resize);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "FormRoomOptions";
+            Text = "Room Options";
+            groupBox_resize.ResumeLayout(false);
+            groupBox_resize.PerformLayout();
+            groupBox_clear.ResumeLayout(false);
+            groupBox_clear.PerformLayout();
+            ResumeLayout(false);
         }
 
         #endregion
@@ -262,8 +305,8 @@
         private System.Windows.Forms.GroupBox groupBox_clear;
         private System.Windows.Forms.Button button_close;
         private System.Windows.Forms.Label label_blocks;
-        private System.Windows.Forms.Label label_screenY;
-        private System.Windows.Forms.Label label_screenX;
         private System.Windows.Forms.Label label_screens;
+        private Theming.CustomControls.FlatTextBox textbox_screenY;
+        private Theming.CustomControls.FlatTextBox textbox_screenX;
     }
 }

--- a/mage/Tools/FormRoomOptions.Designer.cs
+++ b/mage/Tools/FormRoomOptions.Designer.cs
@@ -46,6 +46,9 @@
             label_screens = new System.Windows.Forms.Label();
             groupBox_clear = new System.Windows.Forms.GroupBox();
             button_close = new System.Windows.Forms.Button();
+            checkBox_sprites = new System.Windows.Forms.CheckBox();
+            checkBox_doors = new System.Windows.Forms.CheckBox();
+            checkBox_scrolls = new System.Windows.Forms.CheckBox();
             groupBox_resize.SuspendLayout();
             groupBox_clear.SuspendLayout();
             SuspendLayout();
@@ -179,7 +182,7 @@
             groupBox_resize.Controls.Add(textBox_height);
             groupBox_resize.Controls.Add(label_height);
             groupBox_resize.Controls.Add(button_resize);
-            groupBox_resize.Location = new System.Drawing.Point(122, 14);
+            groupBox_resize.Location = new System.Drawing.Point(182, 14);
             groupBox_resize.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_resize.Name = "groupBox_resize";
             groupBox_resize.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -242,6 +245,9 @@
             // 
             // groupBox_clear
             // 
+            groupBox_clear.Controls.Add(checkBox_scrolls);
+            groupBox_clear.Controls.Add(checkBox_doors);
+            groupBox_clear.Controls.Add(checkBox_sprites);
             groupBox_clear.Controls.Add(checkBox_bg0);
             groupBox_clear.Controls.Add(checkBox_bg1);
             groupBox_clear.Controls.Add(button_clearBG);
@@ -251,14 +257,14 @@
             groupBox_clear.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox_clear.Name = "groupBox_clear";
             groupBox_clear.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox_clear.Size = new System.Drawing.Size(102, 162);
+            groupBox_clear.Size = new System.Drawing.Size(160, 162);
             groupBox_clear.TabIndex = 0;
             groupBox_clear.TabStop = false;
-            groupBox_clear.Text = "Clear BG";
+            groupBox_clear.Text = "Clear Data";
             // 
             // button_close
             // 
-            button_close.Location = new System.Drawing.Point(206, 151);
+            button_close.Location = new System.Drawing.Point(266, 151);
             button_close.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             button_close.Name = "button_close";
             button_close.Size = new System.Drawing.Size(88, 27);
@@ -267,11 +273,44 @@
             button_close.UseVisualStyleBackColor = true;
             button_close.Click += button_close_Click;
             // 
+            // checkBox_sprites
+            // 
+            checkBox_sprites.AutoSize = true;
+            checkBox_sprites.Location = new System.Drawing.Point(90, 22);
+            checkBox_sprites.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_sprites.Name = "checkBox_sprites";
+            checkBox_sprites.Size = new System.Drawing.Size(61, 19);
+            checkBox_sprites.TabIndex = 5;
+            checkBox_sprites.Text = "Sprites";
+            checkBox_sprites.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_doors
+            // 
+            checkBox_doors.AutoSize = true;
+            checkBox_doors.Location = new System.Drawing.Point(90, 48);
+            checkBox_doors.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_doors.Name = "checkBox_doors";
+            checkBox_doors.Size = new System.Drawing.Size(57, 19);
+            checkBox_doors.TabIndex = 6;
+            checkBox_doors.Text = "Doors";
+            checkBox_doors.UseVisualStyleBackColor = true;
+            // 
+            // checkBox_scrolls
+            // 
+            checkBox_scrolls.AutoSize = true;
+            checkBox_scrolls.Location = new System.Drawing.Point(90, 75);
+            checkBox_scrolls.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox_scrolls.Name = "checkBox_scrolls";
+            checkBox_scrolls.Size = new System.Drawing.Size(60, 19);
+            checkBox_scrolls.TabIndex = 7;
+            checkBox_scrolls.Text = "Scrolls";
+            checkBox_scrolls.UseVisualStyleBackColor = true;
+            // 
             // FormRoomOptions
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(308, 192);
+            ClientSize = new System.Drawing.Size(367, 192);
             Controls.Add(button_close);
             Controls.Add(groupBox_clear);
             Controls.Add(groupBox_resize);
@@ -308,5 +347,8 @@
         private System.Windows.Forms.Label label_screens;
         private Theming.CustomControls.FlatTextBox textbox_screenY;
         private Theming.CustomControls.FlatTextBox textbox_screenX;
+        private System.Windows.Forms.CheckBox checkBox_scrolls;
+        private System.Windows.Forms.CheckBox checkBox_doors;
+        private System.Windows.Forms.CheckBox checkBox_sprites;
     }
 }

--- a/mage/Tools/FormRoomOptions.cs
+++ b/mage/Tools/FormRoomOptions.cs
@@ -1,4 +1,5 @@
 ﻿using mage.Theming;
+using mage.Theming.CustomControls;
 using System;
 using System.Drawing;
 using System.Windows.Forms;
@@ -10,6 +11,8 @@ namespace mage
         // fields
         private FormMain main;
         private Room room;
+        private bool updatedScreenBoxes = false;
+        private bool updatedBlocksBoxes = false;
 
         // constructor
         public FormRoomOptions(FormMain main)
@@ -32,10 +35,14 @@ namespace mage
 
             textBox_width.Text = Hex.ToString(room.Width);
             textBox_height.Text = Hex.ToString(room.Height);
+
+            textbox_screenX.TextChanged += textbox_screenX_TextChanged;
+            textbox_screenY.TextChanged += textbox_screenY_TextChanged;
         }
 
-        private void UpdateText(TextBox textBox, Label label, int size)
+        private void UpdateTextScreen(FlatTextBox textBox, FlatTextBox label, int size)
         {
+            updatedScreenBoxes = true;
             try
             {
                 double screen = Hex.ToByte(textBox.Text);
@@ -47,24 +54,45 @@ namespace mage
                 }
                 else
                 {
-                    label.ForeColor = Color.DarkRed;
+                    label.ForeColor = ThemeSwitcher.ProjectTheme.AccentColor;
                 }
             }
             catch
             {
                 label.Text = "–";
-                label.ForeColor = Color.DarkRed;
+                label.ForeColor = ThemeSwitcher.ProjectTheme.AccentColor;
             }
+            updatedScreenBoxes = false;
+        }
+
+        private void UpdateTextBlocks(FlatTextBox textBox, FlatTextBox label, int size)
+        {
+            updatedBlocksBoxes = true;
+            try
+            {
+                textBox.ForeColor = ThemeSwitcher.ProjectTheme.TextColor;
+                int blocks = Hex.ToByte(textBox.Text);
+                blocks = blocks * size + 4;
+                label.Text = Hex.ToString(blocks);
+            }
+            catch
+            {
+                label.Text = "0";
+                textBox.ForeColor = ThemeSwitcher.ProjectTheme.AccentColor;
+            }
+            updatedBlocksBoxes = false;
         }
 
         private void textBox_width_TextChanged(object sender, EventArgs e)
         {
-            UpdateText(textBox_width, label_screenX, 15);
+            if (updatedBlocksBoxes) return;
+            UpdateTextScreen(textBox_width, textbox_screenX, 15);
         }
 
         private void textBox_height_TextChanged(object sender, EventArgs e)
         {
-            UpdateText(textBox_height, label_screenY, 10);
+            if (updatedBlocksBoxes) return;
+            UpdateTextScreen(textBox_height, textbox_screenY, 10);
         }
 
         private void button_clearBG_Click(object sender, EventArgs e)
@@ -105,7 +133,7 @@ namespace mage
             }
             catch (Exception ex)
             {
-                MessageBox.Show("One of the values entered was not valid.\n\n" + ex.Message, 
+                MessageBox.Show("One of the values entered was not valid.\n\n" + ex.Message,
                     "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
@@ -131,6 +159,16 @@ namespace mage
             Close();
         }
 
-        
+        private void textbox_screenX_TextChanged(object sender, EventArgs e)
+        {
+            if (updatedScreenBoxes) return;
+            UpdateTextBlocks(sender as FlatTextBox, textBox_width, 15);
+        }
+
+        private void textbox_screenY_TextChanged(object sender, EventArgs e)
+        {
+            if (updatedScreenBoxes) return;
+            UpdateTextBlocks(sender as FlatTextBox, textBox_height, 10);
+        }
     }
 }

--- a/mage/Tools/FormRoomOptions.cs
+++ b/mage/Tools/FormRoomOptions.cs
@@ -118,8 +118,27 @@ namespace mage
                 checkBox_clip.Checked = false;
             }
 
+            if (checkBox_sprites.Checked)
+            {
+                foreach (EnemyList l in room.enemyLists) l?.Clear();
+                checkBox_sprites.Checked = false;
+            }
+
+            if (checkBox_doors.Checked)
+            {
+                room.doorList.Clear();
+                checkBox_doors.Checked = false;
+            }
+
+            if (checkBox_scrolls.Checked)
+            {
+                room.scrollList.Clear();
+                checkBox_scrolls.Checked = false;
+            }
+
             main.ReloadRoom(true);
             room = main.Room;
+            main.UpdateUiAfterClear();
         }
 
         private void button_resize_Click(object sender, EventArgs e)

--- a/mage/Tools/FormRoomOptions.resx
+++ b/mage/Tools/FormRoomOptions.resx
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
     <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
     <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/mage/mage.csproj
+++ b/mage/mage.csproj
@@ -44,9 +44,7 @@
     <Compile Update="TileView.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Update="RoomView.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Update="RoomView.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Icons\button_bg_color.png" />


### PR DESCRIPTION
Some small QOL changes:

* Clicking "Auto connect" in the Door Editor enables the apply button 
* Double clicking on an object in object editing mode allows you to edit sprites, doors or scrolls respectively
* click + drag in minimap editor to draw tiles
* In the room options the wanted screen number can be directly instead of having to use blocks
  * The screen number is represented as a hex value
* Added a label for the [\xBXXX] characters in Fusion. They are for stopping music. [MUSIC_STOP=X].
* Text editor preview can be zoomed and the window can be properly scaled
* Input a 24bit color in palette editor which gets converted to the nearest 15bit color

These are all things I always wished were in MAGE for a long time. Especially the first and last change make the editing experience far easier